### PR TITLE
notification 화면

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/base/BaseViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/base/BaseViewModel.kt
@@ -6,15 +6,20 @@ import com.ssafy.neegongnaegong.domain.exception.ApiException
 import com.ssafy.neegongnaegong.domain.exception.AuthException
 import com.ssafy.neegongnaegong.presentation.util.AuthManager
 import com.ssafy.neegongnaegong.presentation.util.SnackbarManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -166,6 +171,31 @@ abstract class BaseViewModel<Event : UiEvent, State : UiState, Effect : UiEffect
     }
 
     /**
+     * 안전하게 suspend 블록을 실행하는 함수
+     * 성공 시 [onSuccess] 블록을 호출하고,
+     * 실패 시 [_handleException]로 공통 에러 로직 처리 후,
+     * [retry]를 통해 재시도 로직을 연결할 수 있음
+     *
+     * @param onSuccess suspend 블록 실행 성공 시 호출될 콜백
+     * @param errorContext ErrorContext – 에러 처리 컨텍스트
+     * @param retry 실패 시 재시도할 로직
+     * @param block 실행할 suspend 블록
+     */
+    protected open fun <Result> CoroutineScope.safeLaunch(
+        onSuccess: (Result) -> Unit = {},
+        errorContext: ErrorContext? = null,
+        retry: () -> Unit = {},
+        block: suspend () -> Result
+    ): Job = launch {
+        runCatching { block() }
+            .onSuccess { result: Result -> onSuccess(result) }
+            .onFailure { throwable: Throwable ->
+                _handleException<Result>(e = throwable, errorContext = errorContext, retry = retry)
+            }
+    }
+
+
+    /**
      * safeCollect 중 발생한 예외를 처리하는 함수
      * 공통 에러를 처리하고, 추가적인 에러 처리는 handleErrorContext에 전달
      *
@@ -204,6 +234,18 @@ abstract class BaseViewModel<Event : UiEvent, State : UiState, Effect : UiEffect
     }
 
     /**
+     * Flow를 ViewModel에서 사용할 수 있는 StateFlow로 변환하는 확장 함수입니다.
+     *
+     * @param initValue 초기 상태 값입니다. 화면이 처음 구성될 때 사용할 기본 값입니다.
+     * @return ViewModel 범위(viewModelScope) 내에서 구독되는 StateFlow를 반환합니다.
+     */
+    protected fun <T> Flow<T>.toViewModelState(initValue: T): StateFlow<T> = stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = TIME_OUT),
+        initialValue = initValue
+    )
+
+    /**
      * ErrorContext에 따라 예외를 처리하는 함수
      * 상속 시 각 ViewModel에서 추가적인 에러 처리를 할 수 있음
      *
@@ -214,4 +256,8 @@ abstract class BaseViewModel<Event : UiEvent, State : UiState, Effect : UiEffect
      * @param retry 재시도 콜백
      */
     open fun handleException(e: Throwable, errorContext: ErrorContext, retry: () -> Unit) {}
+
+    companion object {
+        protected const val TIME_OUT: Long = 5_000L
+    }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/base/UiEffect.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/base/UiEffect.kt
@@ -1,3 +1,17 @@
 package com.ssafy.neegongnaegong.presentation.base
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.flow.Flow
+
 interface UiEffect
+
+@Composable
+fun <E : UiEffect> CollectSideEffects(
+    effectFlow: Flow<E>,
+    onEffect: suspend (E) -> Unit
+) = LaunchedEffect(key1 = effectFlow) {
+    effectFlow.collect { effect: E ->
+        onEffect(effect)
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/refresh/DefaultRefreshBox.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/refresh/DefaultRefreshBox.kt
@@ -1,0 +1,45 @@
+package com.ssafy.neegongnaegong.presentation.component.refresh
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DefaultRefreshBox(
+    modifier: Modifier = Modifier,
+    scope: CoroutineScope = rememberCoroutineScope(),
+    state: PullToRefreshState = rememberPullToRefreshState(),
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
+    content: @Composable BoxScope.() -> Unit
+) {
+    PullToRefreshBox(
+        modifier = modifier,
+        isRefreshing = isRefreshing,
+        onRefresh = {
+            onRefresh()
+            scope.launch { state.animateToHidden() }
+        },
+        state = state,
+        content = content,
+        indicator = {
+            Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                containerColor = MaterialTheme.colorScheme.background,
+                isRefreshing = isRefreshing,
+                state = state
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
@@ -113,7 +113,7 @@ object AppNavigation {
             ) : Profile
 
             @Serializable
-            data object Notification: Screen
+            data object Notification: Profile
         }
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
@@ -111,6 +111,9 @@ object AppNavigation {
             data class Main(
                 val userId: Int = -1,
             ) : Profile
+
+            @Serializable
+            data object Notification: Screen
         }
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/ProfileNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/ProfileNavGraph.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.ssafy.neegongnaegong.presentation.ProfileScreen
+import com.ssafy.neegongnaegong.presentation.notification.notificationScreen
 
 fun NavGraphBuilder.profileNavGraph(navController: NavController){
     navigation<AppNavigation.Tab.Profile>(
@@ -13,5 +14,7 @@ fun NavGraphBuilder.profileNavGraph(navController: NavController){
         composable<AppNavigation.Screen.Profile.Main> {
             ProfileScreen()
         }
+
+        notificationScreen()
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/ProfileNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/ProfileNavGraph.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.ssafy.neegongnaegong.presentation.ProfileScreen
-import com.ssafy.neegongnaegong.presentation.notification.notificationScreen
+import com.ssafy.neegongnaegong.presentation.notification.NotificationRoute
 
 fun NavGraphBuilder.profileNavGraph(navController: NavController){
     navigation<AppNavigation.Tab.Profile>(
@@ -15,6 +15,8 @@ fun NavGraphBuilder.profileNavGraph(navController: NavController){
             ProfileScreen()
         }
 
-        notificationScreen()
+        composable<AppNavigation.Screen.Profile.Notification> {
+            NotificationRoute()
+        }
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationContract.kt
@@ -11,6 +11,7 @@ interface NotificationContract {
         data object RefreshEvent : Event()
         data object DeleteAllNotification : Event()
         data class DeleteNotification(val data: NotificationUiModel) : Event()
+        data class MoveNotification(val data: NotificationUiModel) : Event()
     }
 
     data class State(
@@ -22,7 +23,7 @@ interface NotificationContract {
         data object ScrollToFirstPosition : Effect()
     }
 
-    sealed class Error: ErrorContext {
+    sealed class Error : ErrorContext {
         data object ShowErrorMessage : Error()
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationContract.kt
@@ -1,0 +1,28 @@
+package com.ssafy.neegongnaegong.presentation.notification
+
+import com.ssafy.neegongnaegong.presentation.base.ErrorContext
+import com.ssafy.neegongnaegong.presentation.base.UiEffect
+import com.ssafy.neegongnaegong.presentation.base.UiEvent
+import com.ssafy.neegongnaegong.presentation.base.UiState
+import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
+
+interface NotificationContract {
+    sealed class Event : UiEvent {
+        data object RefreshEvent : Event()
+        data object DeleteAllNotification : Event()
+        data class DeleteNotification(val data: NotificationUiModel) : Event()
+    }
+
+    data class State(
+        val isLoading: Boolean = true,
+    ) : UiState
+
+    sealed class Effect : UiEffect {
+        data class ShowErrorMessage(val message: String) : Effect()
+        data object ScrollToFirstPosition : Effect()
+    }
+
+    sealed class Error: ErrorContext {
+        data object ShowErrorMessage : Error()
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
@@ -13,8 +13,7 @@ import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiMod
 import com.ssafy.neegongnaegong.presentation.util.SnackbarManager
 
 @Composable
-fun NotificationRoute() {
-    val viewModel: NotificationViewModel = hiltViewModel()
+fun NotificationRoute(viewModel: NotificationViewModel = hiltViewModel()) {
     val listState: LazyListState = rememberLazyListState()
     val uiState: NotificationContract.State by viewModel.uiState.collectAsStateWithLifecycle()
     val notificationList: LazyPagingItems<NotificationUiModel> = viewModel

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
@@ -1,0 +1,54 @@
+package com.ssafy.neegongnaegong.presentation.notification
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.ssafy.neegongnaegong.presentation.base.CollectSideEffects
+import com.ssafy.neegongnaegong.presentation.navigation.AppNavigation
+import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
+import com.ssafy.neegongnaegong.presentation.util.SnackbarManager
+
+fun NavGraphBuilder.notificationScreen() = composable<AppNavigation.Screen.Profile.Notification> {
+    val viewModel: NotificationViewModel = hiltViewModel()
+    val listState: LazyListState = rememberLazyListState()
+    val uiState: NotificationContract.State by viewModel.uiState.collectAsStateWithLifecycle()
+    val notificationList: LazyPagingItems<NotificationUiModel> = viewModel
+        .notificationList
+        .collectAsLazyPagingItems()
+
+    CollectSideEffects(effectFlow = viewModel.effect) { effect: NotificationContract.Effect ->
+        when (effect) {
+            is NotificationContract.Effect.ShowErrorMessage -> {
+                SnackbarManager.showErrorMessage(message = effect.message)
+            }
+
+            is NotificationContract.Effect.ScrollToFirstPosition -> {
+                listState.animateScrollToItem(0)
+            }
+        }
+    }
+
+    NotificationScreen(
+        listState = listState,
+        isRefresh = uiState.isLoading,
+        notificationList = notificationList,
+        onRefresh = {
+            val event = NotificationContract.Event.RefreshEvent
+            viewModel.setEvent(event = event)
+        },
+        onDeleteAll = {
+            val event = NotificationContract.Event.DeleteAllNotification
+            viewModel.setEvent(event = event)
+        },
+        onDeleteNotification = { notificationUiModel: NotificationUiModel ->
+            val event = NotificationContract.Event.DeleteNotification(data = notificationUiModel)
+            viewModel.setEvent(event = event)
+        }
+    )
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
@@ -2,19 +2,18 @@ package com.ssafy.neegongnaegong.presentation.notification
 
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.composable
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ssafy.neegongnaegong.presentation.base.CollectSideEffects
-import com.ssafy.neegongnaegong.presentation.navigation.AppNavigation
 import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
 import com.ssafy.neegongnaegong.presentation.util.SnackbarManager
 
-fun NavGraphBuilder.notificationScreen() = composable<AppNavigation.Screen.Profile.Notification> {
+@Composable
+fun NotificationRoute() {
     val viewModel: NotificationViewModel = hiltViewModel()
     val listState: LazyListState = rememberLazyListState()
     val uiState: NotificationContract.State by viewModel.uiState.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
@@ -48,6 +48,10 @@ fun NotificationRoute() {
         onDeleteNotification = { notificationUiModel: NotificationUiModel ->
             val event = NotificationContract.Event.DeleteNotification(data = notificationUiModel)
             viewModel.setEvent(event = event)
+        },
+        onMoveNotification = { notificationUiModel: NotificationUiModel ->
+            val event = NotificationContract.Event.MoveNotification(data = notificationUiModel)
+            viewModel.setEvent(event = event)
         }
     )
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
@@ -35,6 +35,7 @@ fun NotificationScreen(
     onRefresh: () -> Unit,
     onDeleteAll: () -> Unit,
     onDeleteNotification: (NotificationUiModel) -> Unit,
+    onMoveNotification: (NotificationUiModel) -> Unit
 ) {
     DefaultRefreshBox(
         isRefreshing = isRefresh,
@@ -68,7 +69,8 @@ fun NotificationScreen(
                 modifier = Modifier.fillMaxSize(),
                 listState = listState,
                 notificationList = notificationList,
-                onDeleteNotification = onDeleteNotification
+                onDeleteNotification = onDeleteNotification,
+                onMoveNotification = onMoveNotification
             )
         }
     }
@@ -94,6 +96,7 @@ fun NotificationPreviewScreen() {
         notificationList = fakeFlow,
         onRefresh = {},
         onDeleteAll = {},
-        onDeleteNotification = {}
+        onDeleteNotification = {},
+        onMoveNotification = {}
     )
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
@@ -13,12 +13,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.presentation.component.refresh.DefaultRefreshBox
 import com.ssafy.neegongnaegong.presentation.notification.component.NotificationList
 import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
@@ -44,15 +46,26 @@ fun NotificationScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = 24.dp)
+                .padding(top = 20.dp)
         ) {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(id = R.string.notification),
+                    style = NeeGongNaeGongTheme.typography.bodyMedium,
+                    color = NeeGongNaeGongTheme.colorScheme.primaryText
+                )
+            }
+
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp)
             ) {
                 Text(
-                    text = "전체 삭제",
+                    text = stringResource(id = R.string.delete_all),
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
                         .clickable(
@@ -61,7 +74,7 @@ fun NotificationScreen(
                             onClick = onDeleteAll
                         ),
                     textAlign = TextAlign.End,
-                    style = NeeGongNaeGongTheme.typography.bodyMedium,
+                    style = NeeGongNaeGongTheme.typography.bodySmall,
                     color = NeeGongNaeGongTheme.colorScheme.primaryText
                 )
             }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
@@ -1,0 +1,99 @@
+package com.ssafy.neegongnaegong.presentation.notification
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.ssafy.neegongnaegong.presentation.component.refresh.DefaultRefreshBox
+import com.ssafy.neegongnaegong.presentation.notification.component.NotificationList
+import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
+import kotlinx.coroutines.flow.flowOf
+import kotlin.random.Random
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationScreen(
+    isRefresh: Boolean,
+    listState: LazyListState,
+    notificationList: LazyPagingItems<NotificationUiModel>,
+    onRefresh: () -> Unit,
+    onDeleteAll: () -> Unit,
+    onDeleteNotification: (NotificationUiModel) -> Unit,
+) {
+    DefaultRefreshBox(
+        isRefreshing = isRefresh,
+        onRefresh = onRefresh,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 24.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = "전체 삭제",
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .clickable(
+                            indication = null,
+                            interactionSource = null,
+                            onClick = onDeleteAll
+                        ),
+                    textAlign = TextAlign.End,
+                    style = NeeGongNaeGongTheme.typography.bodyMedium,
+                )
+            }
+
+            NotificationList(
+                modifier = Modifier.fillMaxSize(),
+                listState = listState,
+                notificationList = notificationList,
+                onDeleteNotification = onDeleteNotification
+            )
+        }
+    }
+}
+
+
+@Composable
+@Preview
+fun NotificationPreviewScreen() {
+    val testModel = NotificationUiModel(
+        id = Random.nextLong(),
+        image = "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcTRI8A6M23RTePWn8of5fgwRzSMMzRy_6mZP7OrP79VF3ByzCoRcyfx6bYr9w4bH9zdVfpV_LP9hBAudM5SRGyjnbbEhnrs2vWZKF8wySI",
+        user = "홍길동",
+        content = "님이 ㅋㅋㅋ 게시글에 답글을 추가했습니다.",
+        isRead = true
+    )
+    val testList = List<NotificationUiModel>(500) { testModel }
+    val fakeFlow = flowOf(PagingData.from(testList)).collectAsLazyPagingItems()
+
+    NotificationScreen(
+        isRefresh = false,
+        listState = rememberLazyListState(),
+        notificationList = fakeFlow,
+        onRefresh = {},
+        onDeleteAll = {},
+        onDeleteNotification = {}
+    )
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
@@ -62,6 +62,7 @@ fun NotificationScreen(
                         ),
                     textAlign = TextAlign.End,
                     style = NeeGongNaeGongTheme.typography.bodyMedium,
+                    color = NeeGongNaeGongTheme.colorScheme.primaryText
                 )
             }
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
@@ -1,0 +1,95 @@
+package com.ssafy.neegongnaegong.presentation.notification
+
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import com.ssafy.neegongnaegong.presentation.base.BaseViewModel
+import com.ssafy.neegongnaegong.presentation.base.ErrorContext
+import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import kotlin.random.Random
+
+@HiltViewModel
+class NotificationViewModel @Inject constructor(
+
+) : BaseViewModel<NotificationContract.Event, NotificationContract.State, NotificationContract.Effect>() {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val notificationList: StateFlow<PagingData<NotificationUiModel>> by lazy {
+        uiState.distinctUntilChangedBy { uiState: NotificationContract.State ->
+            uiState.isLoading
+        }.filter { uiState: NotificationContract.State ->
+            uiState.isLoading
+        }.flatMapLatest {
+            delay(1500)
+            flowOf(TestPagingData)
+        }.onEach {
+            endLoad()
+        }.cachedIn(viewModelScope)
+            .toViewModelState(PagingData.empty())
+    }
+
+    override fun createInitialState(): NotificationContract.State = NotificationContract.State()
+
+    override fun handleEvent(event: NotificationContract.Event) = when (event) {
+        NotificationContract.Event.RefreshEvent -> handleRefresh()
+        NotificationContract.Event.DeleteAllNotification -> handleDeleteAllNotification()
+        is NotificationContract.Event.DeleteNotification -> handleDeleteNotification(data = event.data)
+    }
+
+    private fun endLoad() {
+        setState { copy(isLoading = false) }
+    }
+
+    private fun handleRefresh() {
+        setState { copy(isLoading = true) }
+
+        val sideEffect = NotificationContract.Effect.ScrollToFirstPosition
+        setEffect { sideEffect }
+    }
+
+    private fun handleDeleteAllNotification() {
+        viewModelScope.safeLaunch(errorContext = NotificationContract.Error.ShowErrorMessage) {
+            TODO("모든 알람을 삭제합니다.")
+        }
+    }
+
+    private fun handleDeleteNotification(data: NotificationUiModel) {
+        viewModelScope.safeLaunch(errorContext = NotificationContract.Error.ShowErrorMessage) {
+            TODO("특정 알람을 삭제합니다. ${data.id}")
+        }
+    }
+
+    override fun handleException(
+        e: Throwable,
+        errorContext: ErrorContext,
+        retry: () -> Unit
+    ) {
+        endLoad()
+
+        val message: String = e.message ?: return
+        val sideEffect = NotificationContract.Effect.ShowErrorMessage(message)
+        setEffect { sideEffect }
+    }
+
+    companion object {
+        val TestModel = NotificationUiModel(
+            id = Random.nextLong(),
+            image = "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcTRI8A6M23RTePWn8of5fgwRzSMMzRy_6mZP7OrP79VF3ByzCoRcyfx6bYr9w4bH9zdVfpV_LP9hBAudM5SRGyjnbbEhnrs2vWZKF8wySI",
+            user = "킹 민 조",
+            content = "님이 길을 나선다 모두 머리를 조아려라",
+            isRead = Random.nextBoolean()
+        )
+        val TestList = List<NotificationUiModel>(500) { TestModel }
+        val TestPagingData = PagingData.from(TestList)
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
@@ -44,6 +44,7 @@ class NotificationViewModel @Inject constructor(
         NotificationContract.Event.RefreshEvent -> handleRefresh()
         NotificationContract.Event.DeleteAllNotification -> handleDeleteAllNotification()
         is NotificationContract.Event.DeleteNotification -> handleDeleteNotification(data = event.data)
+        is NotificationContract.Event.MoveNotification -> handleMoveNotification(data = event.data)
     }
 
     private fun endLoad() {
@@ -65,7 +66,13 @@ class NotificationViewModel @Inject constructor(
 
     private fun handleDeleteNotification(data: NotificationUiModel) {
         viewModelScope.safeLaunch(errorContext = NotificationContract.Error.ShowErrorMessage) {
-            TODO("특정 알람을 삭제합니다. ${data.id}")
+            TODO("알람을 삭제합니다. ${data.id}")
+        }
+    }
+
+    private fun handleMoveNotification(data: NotificationUiModel) {
+        viewModelScope.safeLaunch(errorContext = NotificationContract.Error.ShowErrorMessage) {
+            TODO("알람으로 이동합니다. ${data.id}")
         }
     }
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
@@ -94,9 +94,9 @@ class NotificationViewModel @Inject constructor(
             image = "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcTRI8A6M23RTePWn8of5fgwRzSMMzRy_6mZP7OrP79VF3ByzCoRcyfx6bYr9w4bH9zdVfpV_LP9hBAudM5SRGyjnbbEhnrs2vWZKF8wySI",
             user = "킹 민 조",
             content = "님이 길을 나선다 모두 머리를 조아려라",
-            isRead = Random.nextBoolean()
+            isRead = false
         )
-        val TestList = List<NotificationUiModel>(500) { TestModel }
+        val TestList = List(10) { index -> TestModel.copy(isRead = index >= 5) }
         val TestPagingData = PagingData.from(TestList)
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/Notification.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/Notification.kt
@@ -1,25 +1,38 @@
 package com.ssafy.neegongnaegong.presentation.notification.component
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableFloatState
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -27,12 +40,15 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.skydoves.landscapist.glide.GlideImage
 import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
+import kotlin.math.roundToInt
 
 private val ICON_SIZE = 40.dp
+private val MAX_SLIDE_DISTANCE = 55.dp
 
 @Composable
 fun Notification(
@@ -41,7 +57,65 @@ fun Notification(
     user: String,
     content: String,
     isRead: Boolean,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    onMove: () -> Unit
+) {
+    val offsetX: MutableFloatState = remember { mutableFloatStateOf(0f) }
+    val maxSlideDistancePx: Float = with(LocalDensity.current) { MAX_SLIDE_DISTANCE.toPx() }
+    val animatedOffsetX: Float by animateFloatAsState(
+        targetValue = offsetX.floatValue,
+        animationSpec = tween(durationMillis = 200),
+        label = "offsetX"
+    )
+
+    Box(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .matchParentSize(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .size(MAX_SLIDE_DISTANCE)
+                    .background(color = Color.Red)
+                    .clickable(onClick = onDelete),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Delete,
+                    contentDescription = "Delete",
+                    tint = Color.White,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+
+        NotificationContent(
+            modifier = Modifier
+                .offset { IntOffset(animatedOffsetX.roundToInt(), 0) }
+                .clickable { onMove() }
+                .draggableToRevealAction(
+                    offsetState = offsetX,
+                    maxSlideDistancePx = maxSlideDistancePx
+                ),
+            image = image,
+            user = user,
+            content = content,
+            isRead = isRead
+        )
+    }
+}
+
+@Composable
+private fun NotificationContent(
+    modifier: Modifier = Modifier,
+    image: String,
+    user: String,
+    content: String,
+    isRead: Boolean,
 ) {
     val color: Color = notificationBackgroundColor(isRead = isRead)
 
@@ -73,16 +147,6 @@ fun Notification(
             text = buildText(user = user, content = content),
             style = NeeGongNaeGongTheme.typography.bodySmall,
         )
-
-        Icon(
-            modifier = Modifier.clickable(
-                indication = null,
-                interactionSource = null,
-                onClick = onDelete
-            ),
-            imageVector = Icons.Default.Close,
-            contentDescription = user
-        )
     }
 }
 
@@ -101,6 +165,24 @@ private fun buildText(user: String, content: String): AnnotatedString = buildAnn
     append(content)
 }
 
+fun Modifier.draggableToRevealAction(
+    offsetState: MutableState<Float>,
+    maxSlideDistancePx: Float
+): Modifier = pointerInput(Unit) {
+    detectHorizontalDragGestures(
+        onDragEnd = {
+            val newOffset = if (offsetState.value < -maxSlideDistancePx / 2) {
+                -maxSlideDistancePx
+            } else {
+                0f
+            }
+            offsetState.value = newOffset
+        }
+    ) { _, dragAmount ->
+        val newOffset = (offsetState.value + dragAmount).coerceIn(-maxSlideDistancePx, 0f)
+        offsetState.value = newOffset
+    }
+}
 
 @Composable
 @Preview
@@ -111,6 +193,7 @@ fun NotificationPreview() {
         user = "킹민조",
         content = "님이 게시글을 삭제했습니다.",
         isRead = false,
-        onDelete = {}
+        onDelete = {},
+        onMove = {}
     )
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/Notification.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/Notification.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
@@ -146,16 +145,19 @@ private fun NotificationContent(
             modifier = Modifier.weight(1f),
             text = buildText(user = user, content = content),
             style = NeeGongNaeGongTheme.typography.bodySmall,
+            color = NeeGongNaeGongTheme.colorScheme.primaryText
         )
     }
 }
 
 @Composable
 private fun notificationBackgroundColor(isRead: Boolean): Color {
-    val isDark = isSystemInDarkTheme()
-    val baseColor = if (isDark) Color.Gray else Color.White
-    return if (isRead) lerp(baseColor, Color.LightGray, 0.5f)
-    else baseColor
+    val isDark: Boolean = isSystemInDarkTheme()
+    return if (isDark) {
+        if (isRead) Color(0xFF0D1015) else Color.Gray
+    } else {
+        if (isRead) Color.White else Color(0xFFEFF6FE)
+    }
 }
 
 private fun buildText(user: String, content: String): AnnotatedString = buildAnnotatedString {

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/Notification.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/Notification.kt
@@ -1,0 +1,116 @@
+package com.ssafy.neegongnaegong.presentation.notification.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.skydoves.landscapist.glide.GlideImage
+import com.ssafy.neegongnaegong.R
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
+
+private val ICON_SIZE = 40.dp
+
+@Composable
+fun Notification(
+    modifier: Modifier = Modifier,
+    image: String,
+    user: String,
+    content: String,
+    isRead: Boolean,
+    onDelete: () -> Unit
+) {
+    val color: Color = notificationBackgroundColor(isRead = isRead)
+
+    Row(
+        modifier = modifier
+            .background(color = color)
+            .padding(horizontal = 8.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        GlideImage(
+            modifier = Modifier
+                .size(ICON_SIZE)
+                .clip(CircleShape), // 원형 클리핑
+            imageModel = { image },
+            failure = {
+                Image(
+                    painter = painterResource(id = R.drawable.img_default_profile),
+                    contentDescription = "Default Profile Image",
+                    modifier = Modifier
+                        .size(ICON_SIZE)
+                        .clip(CircleShape)
+                )
+            }
+        )
+
+        Text(
+            modifier = Modifier.weight(1f),
+            text = buildText(user = user, content = content),
+            style = NeeGongNaeGongTheme.typography.bodySmall,
+        )
+
+        Icon(
+            modifier = Modifier.clickable(
+                indication = null,
+                interactionSource = null,
+                onClick = onDelete
+            ),
+            imageVector = Icons.Default.Close,
+            contentDescription = user
+        )
+    }
+}
+
+@Composable
+private fun notificationBackgroundColor(isRead: Boolean): Color {
+    val isDark = isSystemInDarkTheme()
+    val baseColor = if (isDark) Color.Gray else Color.White
+    return if (isRead) lerp(baseColor, Color.LightGray, 0.5f)
+    else baseColor
+}
+
+private fun buildText(user: String, content: String): AnnotatedString = buildAnnotatedString {
+    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+        append(user)
+    }
+    append(content)
+}
+
+
+@Composable
+@Preview
+fun NotificationPreview() {
+    Notification(
+        modifier = Modifier.fillMaxWidth(),
+        image = "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcTRI8A6M23RTePWn8of5fgwRzSMMzRy_6mZP7OrP79VF3ByzCoRcyfx6bYr9w4bH9zdVfpV_LP9hBAudM5SRGyjnbbEhnrs2vWZKF8wySI",
+        user = "킹민조",
+        content = "님이 게시글을 삭제했습니다.",
+        isRead = false,
+        onDelete = {}
+    )
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
@@ -3,7 +3,6 @@ package com.ssafy.neegongnaegong.presentation.notification.component
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.paging.compose.LazyPagingItems
@@ -32,10 +31,6 @@ fun NotificationList(
                 onDelete = { onDeleteNotification(data) },
                 onMove = { onMoveNotification(data) }
             )
-
-            if (index < notificationList.itemCount - 1) {
-                HorizontalDivider()
-            }
         }
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
@@ -1,0 +1,41 @@
+package com.ssafy.neegongnaegong.presentation.notification.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.paging.compose.LazyPagingItems
+import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
+
+@Composable
+fun NotificationList(
+    modifier: Modifier = Modifier,
+    listState: LazyListState,
+    notificationList: LazyPagingItems<NotificationUiModel>,
+    onDeleteNotification: (NotificationUiModel) -> Unit,
+) {
+    LazyColumn(
+        modifier = modifier,
+        state = listState
+    ) {
+        items(notificationList.itemCount) { index: Int ->
+            val data: NotificationUiModel = notificationList[index] ?: return@items
+            Notification(
+                modifier = Modifier.fillMaxWidth(),
+                image = data.image,
+                user = data.user,
+                content = data.content,
+                isRead = data.isRead,
+                onDelete = {
+                    onDeleteNotification(data)
+                }
+            )
+
+            if (index < notificationList.itemCount - 1) {
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
@@ -15,6 +15,7 @@ fun NotificationList(
     listState: LazyListState,
     notificationList: LazyPagingItems<NotificationUiModel>,
     onDeleteNotification: (NotificationUiModel) -> Unit,
+    onMoveNotification: (NotificationUiModel) -> Unit
 ) {
     LazyColumn(
         modifier = modifier,
@@ -28,9 +29,8 @@ fun NotificationList(
                 user = data.user,
                 content = data.content,
                 isRead = data.isRead,
-                onDelete = {
-                    onDeleteNotification(data)
-                }
+                onDelete = { onDeleteNotification(data) },
+                onMove = { onMoveNotification(data) }
             )
 
             if (index < notificationList.itemCount - 1) {

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/data/NotificationUiModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/data/NotificationUiModel.kt
@@ -1,0 +1,13 @@
+package com.ssafy.neegongnaegong.presentation.notification.data
+
+import androidx.compose.runtime.Stable
+
+@Stable
+data class NotificationUiModel(
+    // TODO (도메인 레이어와 연결 시에 수정될 수 있습니다.)
+    val id: Long,
+    val image: String,
+    val user: String,
+    val content: String,
+    val isRead: Boolean
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,8 @@
     <string name="txt_dialog_pause">일시 정지</string>
     <string name="txt_dialog_close">종료</string>
 
+    <!--    Notification Screen-->
+    <string name="notification">알람</string>
+    <string name="delete_all">전체 삭제</string>
+
 </resources>


### PR DESCRIPTION
## 📌 연결된 이슈
- #84 

### ✅ 작업 내용
- 알람 리스트 화면 구현 
- 알람 리스트 뷰모델 구현

### 📷 관련 이미지(영상)

https://github.com/user-attachments/assets/7a1735f4-3189-4c3d-a276-913e51d415e1

https://github.com/user-attachments/assets/d565c2bc-9eac-4923-8a72-ead3fdd4e2c6




### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
**해당 PR에는 도메인, 데이터 레이어의 내용이 아닙니다. 오직 presentation layer에 해당되는 부분입니다.**

1. 디자인 요소 중에 맘에 안드시는 부분은 개선하겠슴다
2. 문현이 (서버 알람 파트)랑 이야기 했을 때에는 아래 데이터 정도면 충분하다 생각했습니다. 추가하거나, 변경사항에 대해서는 피드백 주시면 감사하겠습니다 
3. id는 정해지지 않았습니다 (임의의 값) 
4. 로고 주소, 사용자 이름, 내용, 사용자가 읽었는지 여부 정도면 충분하지 않을까 싶습니다.
5. 알람 내역들이 쌓일 수 있다고 생각했을 때 paging이 필요하다 생각해서 paging으로 구현했습니다
```kotlin
@Stable
data class NotificationUiModel(
    // TODO (도메인 레이어와 연결 시에 수정될 수 있습니다.)
    val id: Long,
    val image: String,
    val user: String,
    val content: String,
    val isRead: Boolean
)

```

### 삭제 버튼이 사라지고, slide 시 나오도록 수정했습니다.

@upsk1 @todayis-sunny  @Na2te @limnyn 
