### PR TITLE
notification API 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,4 +123,8 @@ dependencies {
     implementation(libs.paging3.compose)
     // fcm
     implementation(libs.firebase.messaging.ktx)
+
+    // Room
+    implementation(libs.androidx.room.paging)
+    ksp(libs.androidx.room.compiler)
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkNotificationDataSource.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkNotificationDataSource.kt
@@ -1,0 +1,13 @@
+package com.ssafy.neegongnaegong.data.datasource.network
+
+import com.ssafy.neegongnaegong.data.model.notification.NotificationPage
+import kotlinx.coroutines.flow.Flow
+
+interface NetworkNotificationDataSource {
+
+    fun getNotifications(cursorId: Long?, size: Int): Flow<NotificationPage>
+
+    fun deleteNotification(notificationId: Long): Flow<Unit>
+
+    fun deleteAllNotifications(): Flow<Unit>
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkNotificationDataSourceImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkNotificationDataSourceImpl.kt
@@ -1,0 +1,27 @@
+package com.ssafy.neegongnaegong.data.datasource.network
+
+import com.ssafy.neegongnaegong.data.model.apiFlow
+import com.ssafy.neegongnaegong.data.model.notification.NotificationPage
+import com.ssafy.neegongnaegong.data.remote.NotificationApi
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class NetworkNotificationDataSourceImpl @Inject constructor(
+    private val notificationApi: NotificationApi
+) : NetworkNotificationDataSource {
+
+    override fun getNotifications(
+        cursorId: Long?,
+        size: Int
+    ): Flow<NotificationPage> = apiFlow {
+        notificationApi.getNotifications(cursorId = cursorId, size = size)
+    }
+
+    override fun deleteNotification(notificationId: Long): Flow<Unit> = apiFlow {
+        notificationApi.deleteNotification(notificationId = notificationId)
+    }
+
+    override fun deleteAllNotifications(): Flow<Unit> = apiFlow {
+        notificationApi.deleteAllNotifications()
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/NeeGongNaeGongDatabase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/NeeGongNaeGongDatabase.kt
@@ -2,8 +2,8 @@ package com.ssafy.neegongnaegong.data.local.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import com.ssafy.neegongnaegong.data.local.database.dao.NotificationDao
-import com.ssafy.neegongnaegong.data.local.database.dao.NotificationRemoteKeyDao
+import com.ssafy.neegongnaegong.data.local.database.dao.LocalNotificationDataSource
+import com.ssafy.neegongnaegong.data.local.database.dao.LocalNotificationRemoteKeyDataSource
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationRemoteKeyEntity
 
@@ -15,6 +15,6 @@ import com.ssafy.neegongnaegong.data.local.database.entity.NotificationRemoteKey
     version = 1
 )
 abstract class NeeGongNaeGongDatabase : RoomDatabase() {
-    abstract fun notificationDao(): NotificationDao
-    abstract fun notificationRemoteKeyDao(): NotificationRemoteKeyDao
+    abstract fun localNotificationDataSource(): LocalNotificationDataSource
+    abstract fun localNotificationRemoteKeyDataSource(): LocalNotificationRemoteKeyDataSource
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/NeeGongNaeGongDatabase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/NeeGongNaeGongDatabase.kt
@@ -1,0 +1,20 @@
+package com.ssafy.neegongnaegong.data.local.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.ssafy.neegongnaegong.data.local.database.dao.NotificationDao
+import com.ssafy.neegongnaegong.data.local.database.dao.NotificationRemoteKeyDao
+import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
+import com.ssafy.neegongnaegong.data.local.database.entity.NotificationRemoteKeyEntity
+
+@Database(
+    entities = [
+        NotificationEntity::class,
+        NotificationRemoteKeyEntity::class
+    ],
+    version = 1
+)
+abstract class NeeGongNaeGongDatabase : RoomDatabase() {
+    abstract fun notificationDao(): NotificationDao
+    abstract fun notificationRemoteKeyDao(): NotificationRemoteKeyDao
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/dao/LocalNotificationDataSource.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/dao/LocalNotificationDataSource.kt
@@ -8,7 +8,7 @@ import androidx.room.Query
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
 
 @Dao
-interface NotificationDao {
+interface LocalNotificationDataSource {
     @Query("SELECT * FROM notifications ORDER BY createdAt DESC")
     fun getAllNotifications(): PagingSource<Int, NotificationEntity>
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/dao/LocalNotificationRemoteKeyDataSource.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/dao/LocalNotificationRemoteKeyDataSource.kt
@@ -7,7 +7,7 @@ import androidx.room.Query
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationRemoteKeyEntity
 
 @Dao
-interface NotificationRemoteKeyDao {
+interface LocalNotificationRemoteKeyDataSource {
     @Query("SELECT * FROM notification_remote_keys WHERE id = :id")
     suspend fun getRemoteKey(id: Long): NotificationRemoteKeyEntity?
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/dao/NotificationDao.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/dao/NotificationDao.kt
@@ -1,0 +1,23 @@
+package com.ssafy.neegongnaegong.data.local.database.dao
+
+import androidx.paging.PagingSource
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
+
+@Dao
+interface NotificationDao {
+    @Query("SELECT * FROM notifications ORDER BY createdAt DESC")
+    fun getAllNotifications(): PagingSource<Int, NotificationEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(notifications: List<NotificationEntity>)
+
+    @Query("DELETE FROM notifications WHERE id = :notificationId")
+    suspend fun deleteById(notificationId: Long)
+
+    @Query("DELETE FROM notifications")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/dao/NotificationRemoteKeyDao.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/dao/NotificationRemoteKeyDao.kt
@@ -1,0 +1,19 @@
+package com.ssafy.neegongnaegong.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.ssafy.neegongnaegong.data.local.database.entity.NotificationRemoteKeyEntity
+
+@Dao
+interface NotificationRemoteKeyDao {
+    @Query("SELECT * FROM notification_remote_keys WHERE id = :id")
+    suspend fun getRemoteKey(id: Long): NotificationRemoteKeyEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(keys: List<NotificationRemoteKeyEntity>)
+
+    @Query("DELETE FROM notification_remote_keys")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/data/NotificationMapper.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/data/NotificationMapper.kt
@@ -1,0 +1,71 @@
+package com.ssafy.neegongnaegong.data.local.database.data
+
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
+import com.ssafy.neegongnaegong.data.local.database.entity.NotificationRemoteKeyEntity
+import com.ssafy.neegongnaegong.data.model.notification.GetNotificationResponse
+import com.ssafy.neegongnaegong.data.model.notification.NotificationRemoteType
+import com.ssafy.neegongnaegong.domain.model.notification.Notification
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+internal object NotificationMapper {
+
+    fun GetNotificationResponse.toKey(cursorId: Long?) = NotificationRemoteKeyEntity(
+        id = id,
+        nextCursor = cursorId,
+    )
+
+    fun List<GetNotificationResponse>.toKey(cursorId: Long?): List<NotificationRemoteKeyEntity> =
+        map { it.toKey(cursorId = cursorId) }
+
+
+    fun GetNotificationResponse.toEntity() = NotificationEntity(
+        id = id,
+        cursorId = cursorId,
+        receiverId = receiverId,
+        senderId = senderId,
+        notificationType = notificationType.toNotificationType(),
+        senderType = senderType,
+        displayName = displayName,
+        profileImg = profileImg,
+        content = content,
+        createdAt = createdAt.toEpochMilli(),
+        read = read
+    )
+
+    fun List<GetNotificationResponse>.toEntity(): List<NotificationEntity> = map { it.toEntity() }
+
+    fun NotificationEntity.toNotification() = Notification(
+        id = id,
+        cursorId = cursorId,
+        receiverId = receiverId,
+        senderId = senderId,
+        notificationType = notificationType,
+        senderType = senderType,
+        displayName = displayName,
+        profileImg = profileImg,
+        content = content,
+        createdAt = createdAt.toLocalDateTime(),
+        read = read
+    )
+
+    fun PagingData<NotificationEntity>.toNotification(): PagingData<Notification> = map {
+        it.toNotification()
+    }
+
+    fun NotificationRemoteType.toNotificationType() = NotificationType.valueOf(name)
+
+    fun LocalDateTime.toEpochMilli(): Long {
+        val zoneId = ZoneId.systemDefault()
+        val instant = this.atZone(zoneId).toInstant()
+        return instant.toEpochMilli()
+    }
+
+    fun Long.toLocalDateTime(): LocalDateTime {
+        val zoneId = ZoneId.systemDefault()
+        return Instant.ofEpochMilli(this).atZone(zoneId).toLocalDateTime()
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/data/NotificationType.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/data/NotificationType.kt
@@ -1,0 +1,11 @@
+package com.ssafy.neegongnaegong.data.local.database.data
+
+enum class NotificationType {
+    GROUP_JOIN_REQUEST,
+    GROUP_JOIN_APPROVE,
+    GROUP_JOIN_REJECT,
+    NOTICE_POSTED,
+    VOTE_CREATED,
+    VOTE_ENDED,
+    SYSTEM
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/entity/NotificationEntity.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/entity/NotificationEntity.kt
@@ -1,0 +1,21 @@
+package com.ssafy.neegongnaegong.data.local.database.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.ssafy.neegongnaegong.data.local.database.data.NotificationType
+
+@Entity(tableName = "notifications")
+data class NotificationEntity(
+    @PrimaryKey
+    val id: Long,
+    val cursorId: Long,
+    val receiverId: Long,
+    val senderId: Long,
+    val notificationType: NotificationType,
+    val senderType: String,
+    val displayName: String,
+    val profileImg: String,
+    val content: String,
+    val createdAt: Long,
+    val read: Boolean
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/entity/NotificationRemoteKeyEntity.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/entity/NotificationRemoteKeyEntity.kt
@@ -1,0 +1,11 @@
+package com.ssafy.neegongnaegong.data.local.database.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "notification_remote_keys")
+data class NotificationRemoteKeyEntity(
+    @PrimaryKey
+    val id: Long,
+    val nextCursor: Long?,
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/module/DBModule.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/module/DBModule.kt
@@ -1,0 +1,41 @@
+package com.ssafy.neegongnaegong.data.local.database.module
+
+import android.content.Context
+import androidx.room.Room
+import com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase
+import com.ssafy.neegongnaegong.data.local.database.dao.NotificationDao
+import com.ssafy.neegongnaegong.data.local.database.dao.NotificationRemoteKeyDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DBModule {
+
+    @Singleton
+    @Provides
+    fun providesDatabase(
+        @ApplicationContext context: Context
+    ): NeeGongNaeGongDatabase = Room
+        .databaseBuilder(
+            context = context,
+            klass = NeeGongNaeGongDatabase::class.java,
+            name = "neegongnaegong.db"
+        ).build()
+
+
+    @Singleton
+    @Provides
+    fun providesNotificationDao(neeGongNaeGongDatabase: NeeGongNaeGongDatabase): NotificationDao =
+        neeGongNaeGongDatabase.notificationDao()
+
+    @Singleton
+    @Provides
+    fun providesNotificationRemoteKeyDao(neeGongNaeGongDatabase: NeeGongNaeGongDatabase): NotificationRemoteKeyDao =
+        neeGongNaeGongDatabase.notificationRemoteKeyDao()
+
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/module/DBModule.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/module/DBModule.kt
@@ -3,8 +3,8 @@ package com.ssafy.neegongnaegong.data.local.database.module
 import android.content.Context
 import androidx.room.Room
 import com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase
-import com.ssafy.neegongnaegong.data.local.database.dao.NotificationDao
-import com.ssafy.neegongnaegong.data.local.database.dao.NotificationRemoteKeyDao
+import com.ssafy.neegongnaegong.data.local.database.dao.LocalNotificationDataSource
+import com.ssafy.neegongnaegong.data.local.database.dao.LocalNotificationRemoteKeyDataSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -30,12 +30,14 @@ object DBModule {
 
     @Singleton
     @Provides
-    fun providesNotificationDao(neeGongNaeGongDatabase: NeeGongNaeGongDatabase): NotificationDao =
-        neeGongNaeGongDatabase.notificationDao()
+    fun providesLocalNotificationDataSource(
+        neeGongNaeGongDatabase: NeeGongNaeGongDatabase
+    ): LocalNotificationDataSource = neeGongNaeGongDatabase.localNotificationDataSource()
 
     @Singleton
     @Provides
-    fun providesNotificationRemoteKeyDao(neeGongNaeGongDatabase: NeeGongNaeGongDatabase): NotificationRemoteKeyDao =
-        neeGongNaeGongDatabase.notificationRemoteKeyDao()
+    fun providesLocalNotificationRemoteKeyDataSource(
+        neeGongNaeGongDatabase: NeeGongNaeGongDatabase
+    ): LocalNotificationRemoteKeyDataSource = neeGongNaeGongDatabase.localNotificationRemoteKeyDataSource()
 
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/notification/GetNotificationResponse.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/notification/GetNotificationResponse.kt
@@ -1,0 +1,17 @@
+package com.ssafy.neegongnaegong.data.model.notification
+
+import java.time.LocalDateTime
+
+data class GetNotificationResponse(
+    val id: Long,
+    val cursorId: Long,
+    val receiverId: Long,
+    val senderId: Long,
+    val notificationType: NotificationRemoteType,
+    val senderType: String,
+    val displayName: String,
+    val profileImg: String,
+    val content: String,
+    val createdAt: LocalDateTime,
+    val read: Boolean,
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/notification/NotificationPage.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/notification/NotificationPage.kt
@@ -1,0 +1,7 @@
+package com.ssafy.neegongnaegong.data.model.notification
+
+data class NotificationPage(
+    val content: List<GetNotificationResponse>,
+    val hasNext: Boolean,
+    val cursorId: Long?
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/notification/NotificationRemoteType.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/notification/NotificationRemoteType.kt
@@ -1,0 +1,11 @@
+package com.ssafy.neegongnaegong.data.model.notification
+
+enum class NotificationRemoteType {
+    GROUP_JOIN_REQUEST,
+    GROUP_JOIN_APPROVE,
+    GROUP_JOIN_REJECT,
+    NOTICE_POSTED,
+    VOTE_CREATED,
+    VOTE_ENDED,
+    SYSTEM
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/paging/NotificationRemoteMediator.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/paging/NotificationRemoteMediator.kt
@@ -8,8 +8,8 @@ import androidx.paging.RemoteMediator
 import androidx.room.withTransaction
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkNotificationDataSource
 import com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase
-import com.ssafy.neegongnaegong.data.local.database.dao.NotificationDao
-import com.ssafy.neegongnaegong.data.local.database.dao.NotificationRemoteKeyDao
+import com.ssafy.neegongnaegong.data.local.database.dao.LocalNotificationDataSource
+import com.ssafy.neegongnaegong.data.local.database.dao.LocalNotificationRemoteKeyDataSource
 import com.ssafy.neegongnaegong.data.local.database.data.NotificationMapper.toEntity
 import com.ssafy.neegongnaegong.data.local.database.data.NotificationMapper.toKey
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
@@ -20,12 +20,14 @@ import javax.inject.Inject
 
 @OptIn(ExperimentalPagingApi::class)
 class NotificationRemoteMediator @Inject constructor(
-    private val notificationDataSource: NetworkNotificationDataSource,
+    private val networkNotificationDataSource: NetworkNotificationDataSource,
     private val database: NeeGongNaeGongDatabase
 ) : RemoteMediator<Int, NotificationEntity>() {
 
-    private val notificationDao: NotificationDao = database.notificationDao()
-    private val remoteKeyDao: NotificationRemoteKeyDao = database.notificationRemoteKeyDao()
+    private val localNotificationDataSource: LocalNotificationDataSource =
+        database.localNotificationDataSource()
+    private val remoteKeyDao: LocalNotificationRemoteKeyDataSource =
+        database.localNotificationRemoteKeyDataSource()
 
     override suspend fun load(
         loadType: LoadType,
@@ -45,7 +47,7 @@ class NotificationRemoteMediator @Inject constructor(
         }
 
         return runCatching {
-            val remotePager: NotificationPage = notificationDataSource.getNotifications(
+            val remotePager: NotificationPage = networkNotificationDataSource.getNotifications(
                 cursorId = cursor,
                 size = state.config.pageSize
             ).first()
@@ -54,11 +56,11 @@ class NotificationRemoteMediator @Inject constructor(
             database.withTransaction {
                 if (loadType == LoadType.REFRESH) {
                     remoteKeyDao.clearAll()
-                    notificationDao.clearAll()
+                    localNotificationDataSource.clearAll()
                 }
 
                 remoteKeyDao.insertAll(keys = remotePager.content.toKey(cursorId = remotePager.cursorId))
-                notificationDao.insertAll(notifications = remotePager.content.toEntity())
+                localNotificationDataSource.insertAll(notifications = remotePager.content.toEntity())
             }
 
             MediatorResult.Success(endOfPaginationReached = endOfPaginationReached)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/paging/NotificationRemoteMediator.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/paging/NotificationRemoteMediator.kt
@@ -1,0 +1,77 @@
+package com.ssafy.neegongnaegong.data.paging
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import androidx.room.withTransaction
+import com.ssafy.neegongnaegong.data.datasource.network.NetworkNotificationDataSource
+import com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase
+import com.ssafy.neegongnaegong.data.local.database.dao.NotificationDao
+import com.ssafy.neegongnaegong.data.local.database.dao.NotificationRemoteKeyDao
+import com.ssafy.neegongnaegong.data.local.database.data.NotificationMapper.toEntity
+import com.ssafy.neegongnaegong.data.local.database.data.NotificationMapper.toKey
+import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
+import com.ssafy.neegongnaegong.data.local.database.entity.NotificationRemoteKeyEntity
+import com.ssafy.neegongnaegong.data.model.notification.NotificationPage
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+@OptIn(ExperimentalPagingApi::class)
+class NotificationRemoteMediator @Inject constructor(
+    private val notificationDataSource: NetworkNotificationDataSource,
+    private val database: NeeGongNaeGongDatabase
+) : RemoteMediator<Int, NotificationEntity>() {
+
+    private val notificationDao: NotificationDao = database.notificationDao()
+    private val remoteKeyDao: NotificationRemoteKeyDao = database.notificationRemoteKeyDao()
+
+    override suspend fun load(
+        loadType: LoadType,
+        state: PagingState<Int, NotificationEntity>
+    ): MediatorResult {
+        val cursor: Long? = when (loadType) {
+            LoadType.REFRESH -> null
+            LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
+            LoadType.APPEND -> {
+                val remoteKey: NotificationRemoteKeyEntity? = getRemoteKeyForLastItem(state = state)
+                if (remoteKey == null) return MediatorResult.Success(endOfPaginationReached = false)
+
+                val nextCursor: Long? = remoteKey.nextCursor
+                if (nextCursor == null) return MediatorResult.Success(endOfPaginationReached = true)
+                nextCursor
+            }
+        }
+
+        return runCatching {
+            val remotePager: NotificationPage = notificationDataSource.getNotifications(
+                cursorId = cursor,
+                size = state.config.pageSize
+            ).first()
+            val endOfPaginationReached: Boolean = !remotePager.hasNext
+
+            database.withTransaction {
+                if (loadType == LoadType.REFRESH) {
+                    remoteKeyDao.clearAll()
+                    notificationDao.clearAll()
+                }
+
+                remoteKeyDao.insertAll(keys = remotePager.content.toKey(cursorId = remotePager.cursorId))
+                notificationDao.insertAll(notifications = remotePager.content.toEntity())
+            }
+
+            MediatorResult.Success(endOfPaginationReached = endOfPaginationReached)
+        }.getOrElse { throwable: Throwable ->
+            MediatorResult.Error(throwable = throwable)
+        }
+    }
+
+    private suspend fun getRemoteKeyForLastItem(state: PagingState<Int, NotificationEntity>): NotificationRemoteKeyEntity? {
+        return state.pages.lastOrNull { page: PagingSource.LoadResult.Page<Int, NotificationEntity> ->
+            page.data.isNotEmpty()
+        }?.data?.lastOrNull()?.let { notification ->
+            remoteKeyDao.getRemoteKey(notification.id)
+        }
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/remote/NotificationApi.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/remote/NotificationApi.kt
@@ -1,0 +1,25 @@
+package com.ssafy.neegongnaegong.data.remote
+
+import com.ssafy.neegongnaegong.data.model.ApiResponse
+import com.ssafy.neegongnaegong.data.model.notification.NotificationPage
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface NotificationApi {
+
+    @GET("api/notifications")
+    suspend fun getNotifications(
+        @Query("cursor-id") cursorId: Long?,
+        @Query("size") size: Int,
+    ): Result<ApiResponse<NotificationPage>>
+
+    @DELETE("/api/notifications/{notification-id}")
+    suspend fun deleteNotification(
+        @Path("notification-id") notificationId: Long
+    ): Result<ApiResponse<Unit>>
+
+    @DELETE("/api/notifications/all")
+    suspend fun deleteAllNotifications(): Result<ApiResponse<Unit>>
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/repository/NotificationRepositoryImpl.kt
@@ -5,7 +5,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkNotificationDataSource
-import com.ssafy.neegongnaegong.data.local.database.dao.NotificationDao
+import com.ssafy.neegongnaegong.data.local.database.dao.LocalNotificationDataSource
 import com.ssafy.neegongnaegong.data.local.database.data.NotificationMapper.toNotification
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
 import com.ssafy.neegongnaegong.data.paging.NotificationRemoteMediator
@@ -19,9 +19,9 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 class NotificationRepositoryImpl @Inject constructor(
-    private val notificationDataSource: NetworkNotificationDataSource,
+    private val networkNotificationDataSource: NetworkNotificationDataSource,
+    private val localNotificationDataSource: LocalNotificationDataSource,
     private val notificationRemoteMediator: NotificationRemoteMediator,
-    private val notificationDao: NotificationDao,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : NotificationRepository {
 
@@ -32,19 +32,19 @@ class NotificationRepositoryImpl @Inject constructor(
             enablePlaceholders = false
         ),
         remoteMediator = notificationRemoteMediator,
-        pagingSourceFactory = { notificationDao.getAllNotifications() }
+        pagingSourceFactory = { localNotificationDataSource.getAllNotifications() }
     ).flow.map { pagingData: PagingData<NotificationEntity> ->
         pagingData.toNotification()
     }.flowOn(context = ioDispatcher)
 
-    override fun deleteNotification(notificationId: Long): Flow<Unit> = notificationDataSource
+    override fun deleteNotification(notificationId: Long): Flow<Unit> = networkNotificationDataSource
         .deleteNotification(notificationId = notificationId)
-        .onEach { notificationDao.deleteById(notificationId = notificationId) }
+        .onEach { localNotificationDataSource.deleteById(notificationId = notificationId) }
         .flowOn(context = ioDispatcher)
 
-    override fun deleteAllNotifications(): Flow<Unit> = notificationDataSource
+    override fun deleteAllNotifications(): Flow<Unit> = networkNotificationDataSource
         .deleteAllNotifications()
-        .onEach { notificationDao.clearAll() }
+        .onEach { localNotificationDataSource.clearAll() }
         .flowOn(context = ioDispatcher)
 
     companion object {

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/repository/NotificationRepositoryImpl.kt
@@ -1,0 +1,53 @@
+package com.ssafy.neegongnaegong.data.repository
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.ssafy.neegongnaegong.data.datasource.network.NetworkNotificationDataSource
+import com.ssafy.neegongnaegong.data.local.database.dao.NotificationDao
+import com.ssafy.neegongnaegong.data.local.database.data.NotificationMapper.toNotification
+import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
+import com.ssafy.neegongnaegong.data.paging.NotificationRemoteMediator
+import com.ssafy.neegongnaegong.domain.repository.NotificationRepository
+import com.ssafy.neegongnaegong.module.di.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+class NotificationRepositoryImpl @Inject constructor(
+    private val notificationDataSource: NetworkNotificationDataSource,
+    private val notificationRemoteMediator: NotificationRemoteMediator,
+    private val notificationDao: NotificationDao,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : NotificationRepository {
+
+    @OptIn(ExperimentalPagingApi::class)
+    override fun getNotifications() = Pager(
+        config = PagingConfig(
+            pageSize = PAGE_SIZE,
+            enablePlaceholders = false
+        ),
+        remoteMediator = notificationRemoteMediator,
+        pagingSourceFactory = { notificationDao.getAllNotifications() }
+    ).flow.map { pagingData: PagingData<NotificationEntity> ->
+        pagingData.toNotification()
+    }.flowOn(context = ioDispatcher)
+
+    override fun deleteNotification(notificationId: Long): Flow<Unit> = notificationDataSource
+        .deleteNotification(notificationId = notificationId)
+        .onEach { notificationDao.deleteById(notificationId = notificationId) }
+        .flowOn(context = ioDispatcher)
+
+    override fun deleteAllNotifications(): Flow<Unit> = notificationDataSource
+        .deleteAllNotifications()
+        .onEach { notificationDao.clearAll() }
+        .flowOn(context = ioDispatcher)
+
+    companion object {
+        const val PAGE_SIZE = 30
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/notification/Notification.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/notification/Notification.kt
@@ -1,0 +1,18 @@
+package com.ssafy.neegongnaegong.domain.model.notification
+
+import com.ssafy.neegongnaegong.data.local.database.data.NotificationType
+import java.time.LocalDateTime
+
+data class Notification(
+    val id: Long,
+    val cursorId: Long,
+    val receiverId: Long,
+    val senderId: Long,
+    val notificationType: NotificationType,
+    val senderType: String,
+    val displayName: String,
+    val profileImg: String,
+    val content: String,
+    val createdAt: LocalDateTime,
+    val read: Boolean,
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/NotificationRepository.kt
@@ -1,0 +1,14 @@
+package com.ssafy.neegongnaegong.domain.repository
+
+import androidx.paging.PagingData
+import com.ssafy.neegongnaegong.domain.model.notification.Notification
+import kotlinx.coroutines.flow.Flow
+
+interface NotificationRepository {
+
+    fun getNotifications(): Flow<PagingData<Notification>>
+
+    fun deleteNotification(notificationId: Long): Flow<Unit>
+
+    fun deleteAllNotifications(): Flow<Unit>
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/notification/DeleteAllNotificationsUseCase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/notification/DeleteAllNotificationsUseCase.kt
@@ -1,0 +1,9 @@
+package com.ssafy.neegongnaegong.domain.usecase.notification
+
+import com.ssafy.neegongnaegong.domain.repository.NotificationRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class DeleteAllNotificationsUseCase @Inject constructor(private val notificationRepository: NotificationRepository) {
+    operator fun invoke(): Flow<Unit> = notificationRepository.deleteAllNotifications()
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/notification/DeleteNotificationUseCase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/notification/DeleteNotificationUseCase.kt
@@ -1,0 +1,10 @@
+package com.ssafy.neegongnaegong.domain.usecase.notification
+
+import com.ssafy.neegongnaegong.domain.repository.NotificationRepository
+import javax.inject.Inject
+
+class DeleteNotificationUseCase @Inject constructor(private val notificationRepository: NotificationRepository) {
+    operator fun invoke(notificationId: Long) = notificationRepository.deleteNotification(
+        notificationId = notificationId
+    )
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/notification/GetNotificationUseCase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/notification/GetNotificationUseCase.kt
@@ -1,0 +1,12 @@
+package com.ssafy.neegongnaegong.domain.usecase.notification
+
+import androidx.paging.PagingData
+import com.ssafy.neegongnaegong.domain.model.notification.Notification
+import com.ssafy.neegongnaegong.domain.repository.NotificationRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetNotificationUseCase @Inject constructor(private val notificationRepository: NotificationRepository) {
+    operator fun invoke(): Flow<PagingData<Notification>> =
+        notificationRepository.getNotifications()
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/module/di/DataSourceModule.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/module/di/DataSourceModule.kt
@@ -10,6 +10,8 @@ import com.ssafy.neegongnaegong.data.datasource.network.NetworkCalendarDataSourc
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkCalendarDataSourceImpl
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkLearningRecordDataSource
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkLearningRecordDataSourceImpl
+import com.ssafy.neegongnaegong.data.datasource.network.NetworkNotificationDataSource
+import com.ssafy.neegongnaegong.data.datasource.network.NetworkNotificationDataSourceImpl
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkStudiesDataSource
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkStudiesDataSourceImpl
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkStudyGroupDataSource
@@ -56,4 +58,10 @@ internal interface DataSourceModule {
     fun bindNetworkLearningRecordDataSource(
         networkLearningRecordDataSourceImpl: NetworkLearningRecordDataSourceImpl,
     ): NetworkLearningRecordDataSource
+
+    @Singleton
+    @Binds
+    fun bindNetworkNotificationDataSource(
+        networkNotificationDataSourceImpl: NetworkNotificationDataSourceImpl
+    ): NetworkNotificationDataSource
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/module/di/NetworkModule.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/module/di/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder
 import com.ssafy.neegongnaegong.BuildConfig
 import com.ssafy.neegongnaegong.data.remote.AuthApi
 import com.ssafy.neegongnaegong.data.remote.LearningRecordApi
+import com.ssafy.neegongnaegong.data.remote.NotificationApi
 import com.ssafy.neegongnaegong.data.remote.StudiesApi
 import com.ssafy.neegongnaegong.data.remote.StudyGroupApi
 import com.ssafy.neegongnaegong.data.remote.UserApi
@@ -24,6 +25,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
@@ -125,4 +127,8 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideLearningRecordApi(@SecureRetrofit retrofit: Retrofit): LearningRecordApi = retrofit.create(LearningRecordApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideNotificationApi(@SecureRetrofit retrofit: Retrofit): NotificationApi = retrofit.create()
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/module/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/module/di/RepositoryModule.kt
@@ -3,12 +3,14 @@ package com.ssafy.neegongnaegong.module.di
 import com.ssafy.neegongnaegong.data.repository.AuthRepositoryImpl
 import com.ssafy.neegongnaegong.data.repository.CalendarRepositoryImpl
 import com.ssafy.neegongnaegong.data.repository.LearningRecordRepositoryImpl
+import com.ssafy.neegongnaegong.data.repository.NotificationRepositoryImpl
 import com.ssafy.neegongnaegong.data.repository.StudiesRepositoryImpl
 import com.ssafy.neegongnaegong.data.repository.StudyGroupRepositoryImpl
 import com.ssafy.neegongnaegong.data.repository.UserRepositoryImpl
 import com.ssafy.neegongnaegong.domain.repository.AuthRepository
 import com.ssafy.neegongnaegong.domain.repository.CalendarRepository
 import com.ssafy.neegongnaegong.domain.repository.LearningRecordRepository
+import com.ssafy.neegongnaegong.domain.repository.NotificationRepository
 import com.ssafy.neegongnaegong.domain.repository.StudiesRepository
 import com.ssafy.neegongnaegong.domain.repository.StudyGroupRepository
 import com.ssafy.neegongnaegong.domain.repository.UserRepository
@@ -44,4 +46,8 @@ interface RepositoryModule {
     @Binds
     @Singleton
     fun bindLearningRepository(learningRecordRepositoryImpl: LearningRecordRepositoryImpl): LearningRecordRepository
+
+    @Binds
+    @Singleton
+    fun bindNotificationRepository(notificationRepositoryImpl: NotificationRepositoryImpl): NotificationRepository
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/base/BaseViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/base/BaseViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.ssafy.neegongnaegong.domain.exception.ApiException
 import com.ssafy.neegongnaegong.domain.exception.AuthException
 import com.ssafy.neegongnaegong.presentation.util.AuthManager
+import com.ssafy.neegongnaegong.presentation.util.FlowUtil.safeFlatMapLatest
 import com.ssafy.neegongnaegong.presentation.util.SnackbarManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -205,6 +206,30 @@ abstract class BaseViewModel<Event : UiEvent, State : UiState, Effect : UiEffect
                 _handleException<Result>(e = throwable, errorContext = errorContext, retry = retry)
             }
     }
+
+    /**
+     * 안전하게 flatMapLatest를 수행하는 확장 함수
+     *
+     * Flow에서 예외가 발생할 수 있는 flatMapLatest 연산을 수행할 때,
+     * 공통 에러 처리 로직 [_handleException]을 통해 예외를 처리하고,
+     * 필요 시 [retry] 블록을 통해 재시도 로직을 연결할 수 있음.
+     *
+     * @param errorContext ErrorContext – 에러 처리 컨텍스트
+     * @param retry 실패 시 재시도할 로직
+     * @param transform 변환할 suspend flatMapLatest 블록
+     *
+     * @return 안전하게 예외 처리가 적용된 Flow<R>
+     */
+    protected fun <T, R> Flow<T>.safeFlatMapLatest(
+        errorContext: ErrorContext? = null,
+        retry: () -> Unit = {},
+        transform: suspend (value: T) -> Flow<R>
+    ) = safeFlatMapLatest(
+        transform = transform,
+        catch = { throwable: Throwable ->
+            _handleException<T>(e = throwable, errorContext = errorContext, retry = retry)
+        }
+    )
 
 
     /**

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationContract.kt
@@ -16,6 +16,7 @@ interface NotificationContract {
 
     data class State(
         val isLoading: Boolean = true,
+        val isModifying: Boolean = false,
     ) : UiState
 
     sealed class Effect : UiEffect {

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ssafy.neegongnaegong.presentation.base.CollectSideEffects
+import com.ssafy.neegongnaegong.presentation.component.LoadingDialog
 import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
 import com.ssafy.neegongnaegong.presentation.util.SnackbarManager
 
@@ -53,4 +54,6 @@ fun NotificationRoute(viewModel: NotificationViewModel = hiltViewModel()) {
             viewModel.setEvent(event = event)
         }
     )
+
+    if (uiState.isModifying) LoadingDialog()
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
@@ -3,24 +3,29 @@ package com.ssafy.neegongnaegong.presentation.notification
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.ssafy.neegongnaegong.domain.model.notification.Notification
+import com.ssafy.neegongnaegong.domain.usecase.notification.DeleteAllNotificationsUseCase
+import com.ssafy.neegongnaegong.domain.usecase.notification.DeleteNotificationUseCase
+import com.ssafy.neegongnaegong.domain.usecase.notification.GetNotificationUseCase
 import com.ssafy.neegongnaegong.presentation.base.BaseViewModel
 import com.ssafy.neegongnaegong.presentation.base.ErrorContext
+import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiMapper.toUiModel
 import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
-import kotlin.random.Random
 
 @HiltViewModel
 class NotificationViewModel @Inject constructor(
-
+    private val getNotificationUseCase: GetNotificationUseCase,
+    private val deleteNotificationUseCase: DeleteNotificationUseCase,
+    private val deleteAllNotificationUseCase: DeleteAllNotificationsUseCase,
 ) : BaseViewModel<NotificationContract.Event, NotificationContract.State, NotificationContract.Effect>() {
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -29,9 +34,10 @@ class NotificationViewModel @Inject constructor(
             uiState.isLoading
         }.filter { uiState: NotificationContract.State ->
             uiState.isLoading
-        }.flatMapLatest {
-            delay(1500)
-            flowOf(TestPagingData)
+        }.safeFlatMapLatest(errorContext = NotificationContract.Error.ShowErrorMessage) {
+            getNotificationUseCase()
+        }.map { pagingData: PagingData<Notification> ->
+            pagingData.toUiModel()
         }.onEach {
             endLoad()
         }.cachedIn(viewModelScope)
@@ -60,19 +66,24 @@ class NotificationViewModel @Inject constructor(
 
     private fun handleDeleteAllNotification() {
         viewModelScope.safeLaunch(errorContext = NotificationContract.Error.ShowErrorMessage) {
-            TODO("모든 알람을 삭제합니다.")
+            deleteAllNotificationUseCase().withLoading { isModifying ->
+                setState { copy(isModifying = isModifying) }
+            }.firstOrNull()
         }
     }
 
     private fun handleDeleteNotification(data: NotificationUiModel) {
         viewModelScope.safeLaunch(errorContext = NotificationContract.Error.ShowErrorMessage) {
-            TODO("알람을 삭제합니다. ${data.id}")
+            deleteNotificationUseCase(notificationId = data.id).withLoading { isModifying ->
+                setState { copy(isModifying = isModifying) }
+            }.firstOrNull()
         }
     }
 
     private fun handleMoveNotification(data: NotificationUiModel) {
         viewModelScope.safeLaunch(errorContext = NotificationContract.Error.ShowErrorMessage) {
             TODO("알람으로 이동합니다. ${data.id}")
+            // TODO(알림 읽음 처리, 화면 전환, 수락,거절 로직이 추가될 예정입니다.)
         }
     }
 
@@ -86,17 +97,5 @@ class NotificationViewModel @Inject constructor(
         val message: String = e.message ?: return
         val sideEffect = NotificationContract.Effect.ShowErrorMessage(message)
         setEffect { sideEffect }
-    }
-
-    companion object {
-        val TestModel = NotificationUiModel(
-            id = Random.nextLong(),
-            image = "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcTRI8A6M23RTePWn8of5fgwRzSMMzRy_6mZP7OrP79VF3ByzCoRcyfx6bYr9w4bH9zdVfpV_LP9hBAudM5SRGyjnbbEhnrs2vWZKF8wySI",
-            user = "킹 민 조",
-            content = "님이 길을 나선다 모두 머리를 조아려라",
-            isRead = false
-        )
-        val TestList = List(10) { index -> TestModel.copy(isRead = index >= 5) }
-        val TestPagingData = PagingData.from(TestList)
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
@@ -20,7 +20,10 @@ fun NotificationList(
         modifier = modifier,
         state = listState
     ) {
-        items(notificationList.itemCount) { index: Int ->
+        items(
+            count = notificationList.itemCount,
+            key = { index: Int -> notificationList[index]?.id ?: index }
+        ) { index: Int ->
             val data: NotificationUiModel = notificationList[index] ?: return@items
             Notification(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/data/NotificationUiMapper.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/data/NotificationUiMapper.kt
@@ -1,0 +1,20 @@
+package com.ssafy.neegongnaegong.presentation.notification.data
+
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.ssafy.neegongnaegong.domain.model.notification.Notification
+
+internal object NotificationUiMapper {
+
+    fun Notification.toUiModel() = NotificationUiModel(
+        id = id,
+        image = profileImg,
+        user = displayName,
+        content = content,
+        isRead = read
+    )
+
+    fun PagingData<Notification>.toUiModel(): PagingData<NotificationUiModel> = map {
+        it.toUiModel()
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/util/FlowUtil.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/util/FlowUtil.kt
@@ -1,0 +1,18 @@
+package com.ssafy.neegongnaegong.presentation.util
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+
+object FlowUtil {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    inline fun <T, R> Flow<T>.safeFlatMapLatest(
+        crossinline transform: suspend (value: T) -> Flow<R>,
+        crossinline catch: (throwable: Throwable) -> Unit
+    ) = flatMapLatest { value: T ->
+        transform(value).catch { throwable: Throwable ->
+            catch(throwable)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,8 @@ paging3 = "3.3.2"
 ktlint = "12.2.0"
 #detekt
 detekt = "1.23.8"
+#room
+roomPaging = "2.7.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -97,6 +99,10 @@ paging3-compose = { group = "androidx.paging", name = "paging-compose", version.
 
 #detekt
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+
+#room
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomPaging" }
+androidx-room-paging = { module = "androidx.room:room-paging", version.ref = "roomPaging" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 📌 연결된 이슈
- #91 

### ✅ 작업 내용
- 알람 Data Layer 구현
- 알람 Domain Layer 구현

### 📷 관련 이미지(영상)

https://github.com/user-attachments/assets/4dda00cd-dd04-4bae-84c8-4ca2aedff988

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)

**RemoteMediator를 이용해서 Local DB에 API로 부터 받아온 알람 페이징 데이터를 저장하고 있습니다.** 
서버로 부터 N개의 데이터를 수집한 뒤에, 만약 특정 알람을 삭제 하는 경우를 상상해보겠습니다. 
특정 알람이 없어졌다고 서버로 페이징 데이터를 다시 요청하는건 리소스 낭비라고 생각합니다. 
이를 위해서 서버로 부터 삭제 요청을 날린 뒤, `local DB`에 있는 알람 데이터를 삭제합니다. 
`room`의 페이징 데이터는 핫스트림으로, 테이블에 변경사항이 있는 경우 다시 `emit`해주는 만큼 삭제했다고 재 요청을 할 필요가 없게 됩니다. 

---

```kotlin
private fun handleMoveNotification(data: NotificationUiModel) {
        viewModelScope.safeLaunch(errorContext = NotificationContract.Error.ShowErrorMessage) {
            TODO("알람으로 이동합니다. ${data.id}")
            // TODO(알림 읽음 처리, 화면 전환, 수락,거절 로직이 추가될 예정입니다.)
        }
    }
```
현재 알람을 눌렀을 때, "어떤 로직이 수행되어야 할 지"는 서버 파트(문현)이와 개발 중에 있습니다. 
이번 PR는 API -> View 연동 파트 이며 다음 이슈에 로직이 추가될 예정입니다.


@upsk1 @todayis-sunny @Na2te 
