### PR TITLE
알림 화면 바텀 내비 숨기기, 탑바 이전 화면 이동하기 추가

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/MainScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/MainScreen.kt
@@ -24,9 +24,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -39,6 +39,7 @@ import com.ssafy.neegongnaegong.presentation.navigation.MainNavigationGraph
 import com.ssafy.neegongnaegong.presentation.personal.PersonalContract
 import com.ssafy.neegongnaegong.presentation.personal.PersonalViewModel
 import com.ssafy.neegongnaegong.presentation.timer.TimerActivity
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
 import com.ssafy.neegongnaegong.presentation.util.StudiesDrawerController
 
@@ -74,18 +75,23 @@ fun MainScreen() {
 
     val showBottomNavigationBar =
         currentDestination?.let { destination ->
-            val isAuthTab =
-                destination.hierarchy.any {
-                    it.hasRoute(AppNavigation.Tab.Auth::class)
+            val isAuthTab: Boolean = destination.hierarchy
+                .any { navDestination: NavDestination ->
+                    navDestination.hasRoute(AppNavigation.Tab.Auth::class)
                 }
 
-            val isEditScreen =
-                destination.hierarchy.any {
-                    it.hasRoute(AppNavigation.Screen.Personal.Edit::class)
+            val isEditScreen: Boolean = destination.hierarchy
+                .any { navDestination: NavDestination ->
+                    navDestination.hasRoute(AppNavigation.Screen.Personal.Edit::class)
                 }
 
-            !isAuthTab && !isEditScreen
-        } ?: true
+            val isNotificationScreen: Boolean = destination.hierarchy
+                .any { navDestination: NavDestination ->
+                    navDestination.hasRoute(AppNavigation.Screen.Profile.Notification::class)
+                }
+
+            !isAuthTab && !isEditScreen && !isNotificationScreen
+        } != false
 
     val isStudiesDrawerOpen by StudiesDrawerController.isOpen.collectAsState()
     val studiesDrawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
@@ -157,10 +163,10 @@ fun MainScreen() {
             // 다른 화면의 Scaffold에서 사용된 값은 빼고서 계산해줌
             Box(
                 modifier =
-                Modifier
-                    .padding(innerPadding)
-                    .consumeWindowInsets(innerPadding)
-                    .background(NeeGongNaeGongTheme.colorScheme.background),
+                    Modifier
+                        .padding(innerPadding)
+                        .consumeWindowInsets(innerPadding)
+                        .background(NeeGongNaeGongTheme.colorScheme.background),
             ) {
                 MainNavigationGraph(navController = navController)
             }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/ProfileNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/ProfileNavGraph.kt
@@ -29,6 +29,7 @@ fun NavGraphBuilder.profileNavGraph(navController: NavController) {
         composable<AppNavigation.Screen.Profile.Notification> {
             // TODO(다른 화면들과 결합되면 수정해야 합니다.)
             NotificationRoute(
+                navigateUp = navController::navigateUp,
                 navigateToGroup = { groupId: Long ->
                     val group = AppNavigation.Screen.Studies.StudiesDetail
                     navController.navigate(route = group)

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationContract.kt
@@ -8,6 +8,7 @@ import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiMod
 
 interface NotificationContract {
     sealed class Event : UiEvent {
+        data object OnNavigateUp: Event()
         data object RefreshEvent : Event()
         data object DeleteAllNotification : Event()
         data class DeleteNotification(val data: NotificationUiModel) : Event()
@@ -25,6 +26,7 @@ interface NotificationContract {
         data class ShowErrorMessage(val message: String) : Effect()
         data object ShowInvalidGroupIdErrorMessage : Effect()
         data object ScrollToFirstPosition : Effect()
+        data object NavigateUp: Effect()
         data class NavigateToGroup(val groupId: Long) : Effect()
         data class NavigateToNotice(val groupId: Long, val noticeId: Long) : Effect()
         data class NavigateToVote(val groupId: Long, val voteId: Long) : Effect()

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
@@ -19,6 +19,7 @@ import com.ssafy.neegongnaegong.presentation.util.SnackbarManager
 @Composable
 fun NotificationRoute(
     viewModel: NotificationViewModel = hiltViewModel(),
+    navigateUp: () -> Unit,
     navigateToGroup: (groupId: Long) -> Unit,
     navigateToNotice: (groupId: Long, noticeId: Long) -> Unit,
     navigateToVote: (groupId: Long, voteId: Long) -> Unit,
@@ -38,6 +39,10 @@ fun NotificationRoute(
 
             is NotificationContract.Effect.ScrollToFirstPosition -> {
                 listState.animateScrollToItem(0)
+            }
+
+            NotificationContract.Effect.NavigateUp -> {
+                navigateUp()
             }
 
             is NotificationContract.Effect.NavigateToGroup -> {
@@ -63,6 +68,10 @@ fun NotificationRoute(
         listState = listState,
         isRefresh = uiState.isLoading,
         notificationList = notificationList,
+        onNavigateUp = {
+            val event = NotificationContract.Event.OnNavigateUp
+            viewModel.setEvent(event = event)
+        },
         onRefresh = {
             val event = NotificationContract.Event.RefreshEvent
             viewModel.setEvent(event = event)

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
@@ -6,9 +6,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -35,6 +39,7 @@ fun NotificationScreen(
     isRefresh: Boolean,
     listState: LazyListState,
     notificationList: LazyPagingItems<NotificationUiModel>,
+    onNavigateUp: () -> Unit,
     onRefresh: () -> Unit,
     onDeleteAll: () -> Unit,
     onDeleteNotification: (NotificationUiModel) -> Unit,
@@ -51,11 +56,20 @@ fun NotificationScreen(
                 .fillMaxSize()
                 .padding(top = 20.dp)
         ) {
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-                contentAlignment = Alignment.Center
-            ) {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Icon(
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .padding(start = 16.dp)
+                        .size(22.dp)
+                        .clickable(onClick = onNavigateUp),
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    tint = NeeGongNaeGongTheme.colorScheme.primaryText,
+                    contentDescription = null
+                )
+
                 Text(
+                    modifier = Modifier.align(Alignment.Center),
                     text = stringResource(id = R.string.notification),
                     style = NeeGongNaeGongTheme.typography.bodyMedium,
                     color = NeeGongNaeGongTheme.colorScheme.primaryText
@@ -118,6 +132,7 @@ fun NotificationPreviewScreen() {
         isRefresh = false,
         listState = rememberLazyListState(),
         notificationList = fakeFlow,
+        onNavigateUp = {},
         onRefresh = {},
         onDeleteAll = {},
         onDeleteNotification = {},

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
@@ -55,6 +55,7 @@ class NotificationViewModel @Inject constructor(
     override fun createInitialState(): NotificationContract.State = NotificationContract.State()
 
     override fun handleEvent(event: NotificationContract.Event) = when (event) {
+        NotificationContract.Event.OnNavigateUp -> handleNavigateUp()
         NotificationContract.Event.RefreshEvent -> handleRefresh()
         NotificationContract.Event.DeleteAllNotification -> handleDeleteAllNotification()
         is NotificationContract.Event.DeleteNotification -> handleDeleteNotification(data = event.data)
@@ -71,6 +72,11 @@ class NotificationViewModel @Inject constructor(
         setState { copy(isLoading = true) }
 
         val sideEffect = NotificationContract.Effect.ScrollToFirstPosition
+        setEffect { sideEffect }
+    }
+
+    private fun handleNavigateUp() {
+        val sideEffect = NotificationContract.Effect.NavigateUp
         setEffect { sideEffect }
     }
 


### PR DESCRIPTION
## 📌 연결된 이슈
- #115 

### ✅ 작업 내용
- 알림 화면에서는 바텀 내비가 보여지지 않습니다.
- 알림 화면에서는 탑바에 arrow back이 추가되어 이전 화면으로 이동할 수 있습니다.

### 📷 관련 이미지(영상)
![image](https://github.com/user-attachments/assets/6334fe2a-d311-4167-ae56-024a48db130b)

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
없습니다.

@upsk1 @todayis-sunny @Na2te 
