### PR TITLE
 feat(#124) 마이페이지 화면 접속 시 마다 읽지 않은 알림이 있는지 확인

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/profile/ProfileContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/profile/ProfileContract.kt
@@ -32,11 +32,14 @@ interface ProfileContract {
         ) : Event()
 
         data object CheckProfileImageWarning : Event()
+
+        object RequestFetchUnReadNotification : Event()
     }
 
     @Stable
     data class State(
         val isInitial: Boolean = true,
+        val shouldFetchUnReadNotification: Boolean = true,
         val isModifying: Boolean = false,
         val isEditing: Boolean = false,
     ) : UiState

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/profile/ProfileRoute.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/profile/ProfileRoute.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent.Builder
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
@@ -72,6 +73,11 @@ fun ProfileRoute(
                 context.startActivity(intent)
             }
         }
+    }
+
+    LaunchedEffect(key1 = Unit) {
+        val event = ProfileContract.Event.RequestFetchUnReadNotification
+        viewModel.setEvent(event = event)
     }
 
     if (uiState.isInitial) {

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/profile/ProfileViewModel.kt
@@ -65,18 +65,25 @@ class ProfileViewModel
             )
         }
 
-        private val hasUnReadNotification: Flow<Boolean> by lazy {
-            uiState.init().safeFlatMapLatest(
-                errorContext = ProfileContract.Error.CantAccessUnReadNotificationInfoError,
-                transform = { checkUnReadNotificationUseCase() },
-            )
-        }
-
         private val showProfileImageWarning: Flow<Boolean> by lazy {
             uiState.init().safeFlatMapLatest(
                 errorContext = ProfileContract.Error.CantAccessShowProfileImageWarningInfoError,
                 transform = { shouldShowProfileImageWarningUseCase() },
             )
+        }
+
+        private val hasUnReadNotification: Flow<Boolean> by lazy {
+            uiState
+                .distinctUntilChangedBy { uiState: ProfileContract.State ->
+                    uiState.shouldFetchUnReadNotification
+                }.filter { uiState: ProfileContract.State ->
+                    uiState.shouldFetchUnReadNotification
+                }.safeFlatMapLatest(
+                    errorContext = ProfileContract.Error.CantAccessUnReadNotificationInfoError,
+                    transform = { checkUnReadNotificationUseCase() },
+                ).onEach {
+                    setState { copy(shouldFetchUnReadNotification = false) }
+                }
         }
 
         override fun createInitialState(): ProfileContract.State = ProfileContract.State()
@@ -93,7 +100,12 @@ class ProfileViewModel
                 is ProfileContract.Event.ChangeNickName -> handleChangeNickName(event.text)
                 is ProfileContract.Event.ChangeImage -> handleChangeProfileImage(event.uri)
                 ProfileContract.Event.CheckProfileImageWarning -> handleCheckProfileImageWarning()
+                ProfileContract.Event.RequestFetchUnReadNotification -> handleFetchUnReadNotification()
             }
+
+        private fun handleFetchUnReadNotification() {
+            setState { copy(shouldFetchUnReadNotification = true) }
+        }
 
         private fun handleNotification() {
             val sideEffect = ProfileContract.Effect.NavigateToNotification


### PR DESCRIPTION
## 📌 연결된 이슈
- #124

### ✅ 작업 내용
- 마이페이지에서 알림에 빨간 점이 바로 안사라지는 버그 해결
- ~~프로필 이미지 경고 알림 7일이 아니라 계속 뜨는 버그 해결~~

### 📷 관련 이미지(영상)

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)

현재 프로필 이미지 경고 알림이 7일에 한 번씩이 아니라 지속적으로 나오는 이슈를 확인하고 있지만... 재현이 안되고 있습니다.
혹시 이 에러에 대해서 경험하신 분이 있다면 꼭 저에게 공지해주세요!!

---

```kotlin
LaunchedEffect(key1 = Unit) {
    val event = ProfileContract.Event.RequestFetchUnReadNotification
    viewModel.setEvent(event = event)
}
```

마이페이지에서 알림이 있는 경우에는 빨간 점이 나오도록 구현했습니다. 이 unRead한 알림이 있는지에 대한 체크는 다른 화면에서 알 방법이 없기 때문에 항상 화면에 접속할 때마다 (`LaunchEffect`) 데이터를 요청하도록 구현하였습니다. 


처음에는 알림 리스트 화면에 접속해서 모든 알림들을 읽으면 `unRead`를 저장하도록 구현하려 했으나 서버로 부터 모든 데이터를 가져오는게 아니라, **페이징**으로 일부 데이터만을 가져오게 됩니다. 그러다 보니, 일부 데이터만 `load` 하고, 읽게 되면.. **모든 알림을 읽었다는 근거**가 되지 않기에 서버로 부터 최대한 자주 요청해서 `unRead`된 알림이 있는지 최신화 하도록 구현하였습니다. 

@upsk1 @todayis-sunny @Na2te 
