### PR TITLE
Feat/#112 vote notice delete

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSource.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSource.kt
@@ -24,6 +24,11 @@ interface NetworkStudyGroupDataSource {
         noticeId: Long,
     ): Flow<StudyGroupNoticeDetailResponse>
 
+    fun deleteNoticeDetail(
+        studyGroupId: Long,
+        noticeId: Long,
+    ): Flow<Unit>
+
     suspend fun getStudyGroupNoticeList(request: StudyGroupNoticeListRequest): Flow<StudyGroupNoticeListBySliceResponse>
 
     fun getStudyGroupVoteDetail(voteId: Long): Flow<StudyGroupVoteDetailResponse>

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSource.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSource.kt
@@ -33,6 +33,11 @@ interface NetworkStudyGroupDataSource {
 
     fun getStudyGroupVoteDetail(voteId: Long): Flow<StudyGroupVoteDetailResponse>
 
+    fun deleteVoteDetail(
+        studyGroupId: Long,
+        voteId: Long,
+    ): Flow<Unit>
+
     fun castVote(
         studyGroupId: Long,
         voteId: Long,

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSourceImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSourceImpl.kt
@@ -83,6 +83,14 @@ class NetworkStudyGroupDataSourceImpl
                 )
             }
 
+        override fun deleteVoteDetail(
+            studyGroupId: Long,
+            noticeId: Long,
+        ): Flow<Unit> =
+            apiFlow {
+                api.deleteVoteDetail(studyGroupId, noticeId)
+            }
+
         override fun castVote(
             studyGroupId: Long,
             voteId: Long,

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSourceImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSourceImpl.kt
@@ -68,6 +68,14 @@ class NetworkStudyGroupDataSourceImpl
                 )
             }
 
+        override fun deleteNoticeDetail(
+            studyGroupId: Long,
+            noticeId: Long,
+        ): Flow<Unit> =
+            apiFlow {
+                api.deleteNoticeDetail(studyGroupId, noticeId)
+            }
+
         override fun getStudyGroupVoteDetail(voteId: Long): Flow<StudyGroupVoteDetailResponse> =
             apiFlow {
                 api.getVoteDetail(
@@ -90,7 +98,11 @@ class NetworkStudyGroupDataSourceImpl
             voteItem: String,
         ): Flow<StudyGroupVoteDetailResponse> =
             apiFlow {
-                api.addNewVoteOption(studyId = studyGroupId, voteId = voteId, voteItem = VoteItemRequest(voteItem))
+                api.addNewVoteOption(
+                    studyId = studyGroupId,
+                    voteId = voteId,
+                    voteItem = VoteItemRequest(voteItem),
+                )
             }
 
         override fun approveStudyGroupJoin(

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/studygroup/StudyGroupNoticeDetailInfoMapper.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/studygroup/StudyGroupNoticeDetailInfoMapper.kt
@@ -12,7 +12,6 @@ internal object StudyGroupNoticeDetailInfoMapper {
             content,
             createdAt,
             modifiedAt,
-            userProfileImage,
             writer.toDomain(),
         )
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/studygroup/response/StudyGroupNoticeDetailResponse.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/studygroup/response/StudyGroupNoticeDetailResponse.kt
@@ -8,6 +8,5 @@ data class StudyGroupNoticeDetailResponse(
     val content: String,
     val createdAt: LocalDateTime,
     val modifiedAt: LocalDateTime,
-    val userProfileImage: String,
     val writer: Writer,
 )

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
@@ -19,8 +19,6 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 import java.time.LocalDateTime
 
-private const val PREFIX = "/api/study-groups"
-
 interface StudyGroupApi {
     // 해당 유저의 주간 태그별 학습시간을 반환하는 함수
     @GET("$PREFIX/{study-group-id}/members/{user-id}/weekly-study-time")
@@ -104,4 +102,8 @@ interface StudyGroupApi {
         @Path("user-id") userId: Long,
         @Query("notification-id") notificationId: Long?,
     ): Result<ApiResponse<Unit>>
+
+    companion object {
+        private const val PREFIX = "/api/study-groups"
+    }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
@@ -10,6 +10,7 @@ import com.ssafy.neegongnaegong.data.model.studygroup.response.StudyGroupVoteDet
 import com.ssafy.neegongnaegong.data.model.studygroup.response.StudyGroupVoteListBySliceResponse
 import com.ssafy.neegongnaegong.data.model.studygroup.response.StudyLogByTagResponse
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -18,7 +19,7 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 import java.time.LocalDateTime
 
-const val PREFIX = "/api/study-groups"
+private const val PREFIX = "/api/study-groups"
 
 interface StudyGroupApi {
     // 해당 유저의 주간 태그별 학습시간을 반환하는 함수
@@ -53,11 +54,17 @@ interface StudyGroupApi {
         @Query("size") size: Int,
     ): Result<ApiResponse<StudyGroupNoticeListBySliceResponse>>
 
-    @GET("$PREFIX/{study-group-id}/notices/{notices-id}")
+    @GET("$PREFIX/{study-group-id}/notices/{notice-id}")
     suspend fun getNoticeDetail(
         @Path("study-group-id") studyGroupId: Long,
-        @Path("notices-id") noticeId: Long,
+        @Path("notice-id") noticeId: Long,
     ): Result<ApiResponse<StudyGroupNoticeDetailResponse>>
+
+    @DELETE("$PREFIX/{study-group-id}/notices/{notice-id}")
+    suspend fun deleteNoticeDetail(
+        @Path("study-group-id") studyGroupId: Long,
+        @Path("notice-id") noticeId: Long,
+    ): Result<ApiResponse<Unit>>
 
     @GET("$PREFIX/vote/detail/{vote-id}")
     suspend fun getVoteDetail(

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
@@ -71,6 +71,12 @@ interface StudyGroupApi {
         @Path("vote-id") voteId: Long,
     ): Result<ApiResponse<StudyGroupVoteDetailResponse>>
 
+    @DELETE("$PREFIX/{study-group-id}/posts/vote/{vote-id}")
+    suspend fun deleteVoteDetail(
+        @Path("study-group-id") studyGroupId: Long,
+        @Path("vote-id") voteId: Long,
+    ): Result<ApiResponse<Unit>>
+
     @POST("$PREFIX/{study-group-id}/posts/votes/participation/{vote-id}")
     suspend fun castVote(
         @Path("study-group-id") studyGroupId: Long,

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/repository/StudyGroupRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/repository/StudyGroupRepositoryImpl.kt
@@ -81,6 +81,11 @@ class StudyGroupRepositoryImpl
         override fun getVoteDetail(voteId: Long): Flow<StudyGroupVoteDetailInfo> =
             dataSource.getStudyGroupVoteDetail(voteId).map { it.toDomain() }.flowOn(ioDispatcher)
 
+        override fun deleteVoteDetail(
+            studyGroupId: Long,
+            voteId: Long,
+        ): Flow<Unit> = dataSource.deleteVoteDetail(studyGroupId, voteId).flowOn(ioDispatcher)
+
         override fun castVote(
             studyGroupId: Long,
             voteId: Long,

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/repository/StudyGroupRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/repository/StudyGroupRepositoryImpl.kt
@@ -73,6 +73,11 @@ class StudyGroupRepositoryImpl
             noticeId: Long,
         ): Flow<StudyGroupNoticeDetailInfo> = dataSource.getStudyGroupNoticeDetail(studyGroupId, noticeId).map { it.toDomain() }
 
+        override fun deleteNoticeDetail(
+            studyGroupId: Long,
+            noticeId: Long,
+        ): Flow<Unit> = dataSource.deleteNoticeDetail(studyGroupId, noticeId).flowOn(ioDispatcher)
+
         override fun getVoteDetail(voteId: Long): Flow<StudyGroupVoteDetailInfo> =
             dataSource.getStudyGroupVoteDetail(voteId).map { it.toDomain() }.flowOn(ioDispatcher)
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/StudyGroupNoticeDetailInfo.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/StudyGroupNoticeDetailInfo.kt
@@ -8,6 +8,5 @@ data class StudyGroupNoticeDetailInfo(
     val content: String,
     val createdAt: LocalDateTime,
     val modifiedAt: LocalDateTime,
-    val userProfileImage: String,
     val writer: Writer,
 )

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/StudyGroupRepository.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/StudyGroupRepository.kt
@@ -24,6 +24,11 @@ interface StudyGroupRepository {
         noticeId: Long,
     ): Flow<StudyGroupNoticeDetailInfo>
 
+    fun deleteNoticeDetail(
+        studyGroupId: Long,
+        noticeId: Long,
+    ): Flow<Unit>
+
     fun getVoteDetail(voteId: Long): Flow<StudyGroupVoteDetailInfo>
 
     fun castVote(

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/StudyGroupRepository.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/StudyGroupRepository.kt
@@ -31,6 +31,11 @@ interface StudyGroupRepository {
 
     fun getVoteDetail(voteId: Long): Flow<StudyGroupVoteDetailInfo>
 
+    fun deleteVoteDetail(
+        studyGroupId: Long,
+        voteId: Long,
+    ): Flow<Unit>
+
     fun castVote(
         studyGroupId: Long,
         voteId: Long,

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/studygroup/DeleteNoticeDetailUseCase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/studygroup/DeleteNoticeDetailUseCase.kt
@@ -1,0 +1,16 @@
+package com.ssafy.neegongnaegong.domain.usecase.studygroup
+
+import com.ssafy.neegongnaegong.domain.repository.StudyGroupRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class DeleteNoticeDetailUseCase
+    @Inject
+    constructor(
+        private val repository: StudyGroupRepository,
+    ) {
+        operator fun invoke(
+            studyGroupId: Long,
+            noticeId: Long,
+        ): Flow<Unit> = repository.deleteNoticeDetail(studyGroupId, noticeId)
+    }

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/studygroup/DeleteVoteDetailUseCase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/studygroup/DeleteVoteDetailUseCase.kt
@@ -1,0 +1,16 @@
+package com.ssafy.neegongnaegong.domain.usecase.studygroup
+
+import com.ssafy.neegongnaegong.domain.repository.StudyGroupRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class DeleteVoteDetailUseCase
+    @Inject
+    constructor(
+        private val repository: StudyGroupRepository,
+    ) {
+        operator fun invoke(
+            studyGroupId: Long,
+            voteId: Long,
+        ): Flow<Unit> = repository.deleteVoteDetail(studyGroupId, voteId)
+    }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/component/PopupMenu.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/component/PopupMenu.kt
@@ -1,0 +1,98 @@
+package com.ssafy.neegongnaegong.presentation.group.list.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
+
+@Composable
+fun PopupMenu(
+    modifier: Modifier = Modifier,
+    showPopup: Boolean,
+    onClickPopup: () -> Unit,
+    onDismissPopup: () -> Unit,
+    onClickDeleteMenu: () -> Unit,
+    onClickEditMenu: () -> Unit,
+) {
+    Box(modifier = modifier) {
+        IconButton(
+            modifier = Modifier.wrapContentSize(),
+            onClick = onClickPopup,
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = "더보기 아이콘",
+                tint = NeeGongNaeGongTheme.colorScheme.primaryText,
+            )
+        }
+        DropdownMenu(
+            expanded = showPopup,
+            onDismissRequest = onDismissPopup,
+            containerColor = NeeGongNaeGongTheme.colorScheme.background,
+        ) {
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .wrapContentWidth(Alignment.CenterHorizontally),
+                        text = "삭제하기",
+                        style = NeeGongNaeGongTheme.typography.labelMedium,
+                        color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+                contentPadding = PaddingValues(0.dp),
+                onClick = onClickDeleteMenu,
+            )
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .wrapContentWidth(Alignment.CenterHorizontally),
+                        text = "수정하기",
+                        style = NeeGongNaeGongTheme.typography.labelMedium,
+                        color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+                contentPadding = PaddingValues(0.dp),
+                onClick = onClickEditMenu,
+            )
+        }
+    }
+}
+
+@Composable
+@NeeGongNaeGongPreviews
+private fun PreviewPopupMenu() {
+    NeeGongNaeGongTheme {
+        PopupMenu(
+            Modifier.fillMaxSize(),
+            true,
+            {},
+            {},
+            {},
+            {},
+        )
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailContract.kt
@@ -3,7 +3,6 @@ package com.ssafy.neegongnaegong.presentation.group.list.notice
 import com.ssafy.neegongnaegong.presentation.base.UiEffect
 import com.ssafy.neegongnaegong.presentation.base.UiEvent
 import com.ssafy.neegongnaegong.presentation.base.UiState
-import com.ssafy.neegongnaegong.presentation.group.vote.VoteContract.Event
 
 class NoticeDetailContract {
     sealed interface Event : UiEvent {
@@ -11,6 +10,14 @@ class NoticeDetailContract {
         data object InvalidAccess : Event
 
         data object OnClickPopBackStackButton : Event
+
+        data object OnDismissPopUp : Event
+
+        data object OnTogglePopup : Event
+
+        data object OnDeleteNotice : Event
+
+        data object OnEditNotice : Event
     }
 
     data class State(
@@ -18,9 +25,12 @@ class NoticeDetailContract {
         val writerProfileImage: String,
         val createdAt: String,
         val content: String,
+        val showPopup: Boolean,
     ) : UiState
 
     sealed interface Effect : UiEffect {
         data object NavigateToBackStack : Effect
+
+        data object NavigateToSubTab : Effect
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailScreen.kt
@@ -2,24 +2,14 @@ package com.ssafy.neegongnaegong.presentation.group.list.notice
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,6 +30,7 @@ import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.glide.GlideImage
 import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.presentation.component.TopAppBar
+import com.ssafy.neegongnaegong.presentation.group.list.component.PopupMenu
 import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Effect.NavigateToBackStack
 import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Event.OnClickPopBackStackButton
 import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Event.OnDeleteNotice
@@ -156,55 +147,13 @@ private fun NoticeDetailScreen(
                     )
                 }
             }
-            Box {
-                IconButton(
-                    modifier = Modifier.wrapContentSize(),
-                    onClick = onClickPopup,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.MoreVert,
-                        contentDescription = "더보기 아이콘",
-                    )
-                }
-                DropdownMenu(
-                    expanded = showPopup,
-                    onDismissRequest = onDismissPopup,
-                    containerColor = NeeGongNaeGongTheme.colorScheme.background,
-                ) {
-                    DropdownMenuItem(
-                        text = {
-                            Text(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .wrapContentWidth(Alignment.CenterHorizontally),
-                                text = "삭제하기",
-                                style = NeeGongNaeGongTheme.typography.labelMedium,
-                                color = NeeGongNaeGongTheme.colorScheme.primaryText,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        },
-                        contentPadding = PaddingValues(0.dp),
-                        onClick = onClickDeleteNotice,
-                    )
-                    DropdownMenuItem(
-                        text = {
-                            Text(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .wrapContentWidth(Alignment.CenterHorizontally),
-                                text = "수정하기",
-                                style = NeeGongNaeGongTheme.typography.labelMedium,
-                                color = NeeGongNaeGongTheme.colorScheme.primaryText,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        },
-                        contentPadding = PaddingValues(0.dp),
-                        onClick = onClickEditNotice,
-                    )
-                }
-            }
+            PopupMenu(
+                showPopup = showPopup,
+                onClickPopup = onClickPopup,
+                onDismissPopup = onDismissPopup,
+                onClickDeleteMenu = onClickDeleteNotice,
+                onClickEditMenu = onClickEditNotice,
+            )
         }
         Text(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailScreen.kt
@@ -2,14 +2,24 @@ package com.ssafy.neegongnaegong.presentation.group.list.notice
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -19,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -30,6 +41,11 @@ import com.skydoves.landscapist.glide.GlideImage
 import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.presentation.component.TopAppBar
 import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Effect.NavigateToBackStack
+import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Event.OnClickPopBackStackButton
+import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Event.OnDeleteNotice
+import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Event.OnDismissPopUp
+import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Event.OnEditNotice
+import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Event.OnTogglePopup
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
 
@@ -38,15 +54,16 @@ fun NoticeDetailRoute(
     backStackEntry: NavBackStackEntry,
     viewModel: NoticeDetailViewModel = hiltViewModel(backStackEntry),
     popBackStack: () -> Boolean,
+    navigateToSubTab: () -> Unit,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collect {
             when (it) {
-                NavigateToBackStack -> {
-                    popBackStack()
-                }
+                NavigateToBackStack -> popBackStack()
+
+                NoticeDetailContract.Effect.NavigateToSubTab -> navigateToSubTab()
             }
         }
     }
@@ -60,66 +77,133 @@ fun NoticeDetailRoute(
                     color = NeeGongNaeGongTheme.colorScheme.primaryText,
                 )
             },
-            onNavigationClick = { viewModel.setEvent(NoticeDetailContract.Event.OnClickPopBackStackButton) },
+            onNavigationClick = { viewModel.setEvent(OnClickPopBackStackButton) },
         )
         NoticeDetailScreen(
             writer = state.writer,
             writerProfileImage = state.writerProfileImage,
             createdAt = state.createdAt,
+            showPopup = state.showPopup,
+            onClickPopup = { viewModel.setEvent(OnTogglePopup) },
+            onDismissPopup = { viewModel.setEvent(OnDismissPopUp) },
+            onClickDeleteNotice = { viewModel.setEvent(OnDeleteNotice) },
+            onClickEditNotice = { viewModel.setEvent(OnEditNotice) },
             content = state.content,
         )
     }
 }
 
 @Composable
-fun NoticeDetailScreen(
+private fun NoticeDetailScreen(
     writer: String,
     writerProfileImage: String,
     createdAt: String,
+    showPopup: Boolean,
+    onClickPopup: () -> Unit,
+    onDismissPopup: () -> Unit,
+    onClickDeleteNotice: () -> Unit,
+    onClickEditNotice: () -> Unit,
     content: String,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(NeeGongNaeGongTheme.paddingScheme.sp3),
         modifier = Modifier.padding(NeeGongNaeGongTheme.paddingScheme.sp3),
     ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(NeeGongNaeGongTheme.paddingScheme.sp2)) {
-            GlideImage(
-                imageModel = { writerProfileImage },
-                loading = { CircularProgressIndicator() },
-                modifier =
-                    Modifier
-                        .size(50.dp)
-                        .clip(RoundedCornerShape(10.dp)),
-                imageOptions =
-                    ImageOptions(
-                        contentScale = ContentScale.Crop,
-                        alignment = Alignment.Center,
-                    ),
-                requestOptions = { RequestOptions().diskCacheStrategy(DiskCacheStrategy.ALL) },
-                failure = {
-                    // 이미지 로드 실패 시 플레이스홀더
-                    Image(
-                        painter = painterResource(id = R.drawable.img_default_profile),
-                        contentDescription = "Profile Image",
-                        modifier =
-                            Modifier
-                                .size(100.dp)
-                                .clip(RoundedCornerShape(10.dp)),
-                        contentScale = ContentScale.Crop,
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Row(
+                modifier = Modifier.weight(1F),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(NeeGongNaeGongTheme.paddingScheme.sp2),
+            ) {
+                GlideImage(
+                    imageModel = { writerProfileImage },
+                    loading = { CircularProgressIndicator() },
+                    modifier =
+                        Modifier
+                            .size(50.dp)
+                            .clip(RoundedCornerShape(10.dp)),
+                    imageOptions =
+                        ImageOptions(
+                            contentScale = ContentScale.Crop,
+                            alignment = Alignment.Center,
+                        ),
+                    requestOptions = { RequestOptions().diskCacheStrategy(DiskCacheStrategy.ALL) },
+                    failure = {
+                        // 이미지 로드 실패 시 플레이스홀더
+                        Image(
+                            painter = painterResource(id = R.drawable.img_default_profile),
+                            contentDescription = "Profile Image",
+                            modifier =
+                                Modifier
+                                    .size(100.dp)
+                                    .clip(RoundedCornerShape(10.dp)),
+                            contentScale = ContentScale.Crop,
+                        )
+                    },
+                )
+                Column(Modifier.weight(1F), verticalArrangement = Arrangement.Center) {
+                    Text(
+                        text = writer,
+                        overflow = TextOverflow.Ellipsis,
+                        style = NeeGongNaeGongTheme.typography.titleSmall,
+                        color = NeeGongNaeGongTheme.colorScheme.primaryText,
                     )
-                },
-            )
-            Column(Modifier.fillMaxWidth()) {
-                Text(
-                    text = writer,
-                    style = NeeGongNaeGongTheme.typography.titleSmall,
-                    color = NeeGongNaeGongTheme.colorScheme.primaryText,
-                )
-                Text(
-                    text = createdAt,
-                    style = NeeGongNaeGongTheme.typography.labelMedium,
-                    color = NeeGongNaeGongTheme.colorScheme.secondaryText,
-                )
+                    Text(
+                        text = createdAt,
+                        overflow = TextOverflow.Ellipsis,
+                        style = NeeGongNaeGongTheme.typography.labelMedium,
+                        color = NeeGongNaeGongTheme.colorScheme.secondaryText,
+                    )
+                }
+            }
+            Box {
+                IconButton(
+                    modifier = Modifier.wrapContentSize(),
+                    onClick = onClickPopup,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.MoreVert,
+                        contentDescription = "더보기 아이콘",
+                    )
+                }
+                DropdownMenu(
+                    expanded = showPopup,
+                    onDismissRequest = onDismissPopup,
+                    containerColor = NeeGongNaeGongTheme.colorScheme.background,
+                ) {
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .wrapContentWidth(Alignment.CenterHorizontally),
+                                text = "삭제하기",
+                                style = NeeGongNaeGongTheme.typography.labelMedium,
+                                color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        contentPadding = PaddingValues(0.dp),
+                        onClick = onClickDeleteNotice,
+                    )
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .wrapContentWidth(Alignment.CenterHorizontally),
+                                text = "수정하기",
+                                style = NeeGongNaeGongTheme.typography.labelMedium,
+                                color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        contentPadding = PaddingValues(0.dp),
+                        onClick = onClickEditNotice,
+                    )
+                }
             }
         }
         Text(
@@ -133,12 +217,17 @@ fun NoticeDetailScreen(
 
 @Composable
 @NeeGongNaeGongPreviews
-fun PreviewNoticeDetailScreen() {
+private fun PreviewNoticeDetailScreen() {
     NeeGongNaeGongTheme {
         NoticeDetailScreen(
             "테스트",
             "ㅈㄷㄹㅈㄷㄹ",
             "ㅈㄷㄹㅈㄷㄹ",
+            true,
+            {},
+            {},
+            {},
+            {},
             "ㅈㄷㄹㅈㄷㄹ",
         )
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -112,7 +112,7 @@ private fun NoticeDetailScreen(
                     modifier =
                         Modifier
                             .size(50.dp)
-                            .clip(RoundedCornerShape(10.dp)),
+                            .clip(CircleShape),
                     imageOptions =
                         ImageOptions(
                             contentScale = ContentScale.Crop,
@@ -127,7 +127,7 @@ private fun NoticeDetailScreen(
                             modifier =
                                 Modifier
                                     .size(100.dp)
-                                    .clip(RoundedCornerShape(10.dp)),
+                                    .clip(CircleShape),
                             contentScale = ContentScale.Crop,
                         )
                     },

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailViewModel.kt
@@ -3,9 +3,12 @@ package com.ssafy.neegongnaegong.presentation.group.list.notice
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.ssafy.neegongnaegong.domain.usecase.studygroup.DeleteNoticeDetailUseCase
 import com.ssafy.neegongnaegong.domain.usecase.studygroup.GetNoticeDetailUseCase
 import com.ssafy.neegongnaegong.presentation.base.BaseViewModel
 import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Effect
+import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Effect.NavigateToBackStack
+import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Effect.NavigateToSubTab
 import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Event
 import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.State
 import com.ssafy.neegongnaegong.presentation.navigation.AppNavigation
@@ -20,6 +23,7 @@ class NoticeDetailViewModel
     constructor(
         savedStateHandle: SavedStateHandle,
         getNoticeDetailUseCase: GetNoticeDetailUseCase,
+        private val deleteNoticeDetailUseCase: DeleteNoticeDetailUseCase,
     ) :
     BaseViewModel<Event, State, Effect>() {
         override fun createInitialState(): State =
@@ -28,13 +32,38 @@ class NoticeDetailViewModel
                 writerProfileImage = "",
                 createdAt = "",
                 content = "",
+                showPopup = false,
             )
 
         override fun handleEvent(event: Event) {
             when (event) {
-                Event.InvalidAccess -> setEffect { Effect.NavigateToBackStack }
+                Event.InvalidAccess -> setEffect { NavigateToBackStack }
 
-                Event.OnClickPopBackStackButton -> setEffect { Effect.NavigateToBackStack }
+                Event.OnClickPopBackStackButton -> setEffect { NavigateToBackStack }
+
+                Event.OnDismissPopUp -> setState { copy(showPopup = false) }
+
+                Event.OnTogglePopup -> setState { copy(showPopup = !showPopup) }
+
+                Event.OnDeleteNotice -> {
+                    viewModelScope.launch {
+                        deleteNoticeDetailUseCase(
+                            studyGroupId = groupId,
+                            noticeId = noticeId,
+                        ).safeCollect {
+                            showSuccessMessage("공지를 삭제했습니다!")
+                            // SubTab으로 돌아가기 전 PopUp 메뉴 숨기고 이동
+                            // setState로 처리하지 않으니 Navigation 될 때 잠깐 살아있는 현상 있었음
+                            setState { copy(showPopup = false) }
+                            setEffect { NavigateToSubTab }
+                        }
+                    }
+                }
+
+                Event.OnEditNotice -> {
+                    showWarningMessage("아직 추가되지 않은 기능이에요! 삭제를 이용해주세요")
+                    setState { copy(showPopup = false) }
+                }
             }
         }
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailContract.kt
@@ -5,7 +5,7 @@ import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupVoteStatusInfo
 import com.ssafy.neegongnaegong.presentation.base.UiEffect
 import com.ssafy.neegongnaegong.presentation.base.UiEvent
 import com.ssafy.neegongnaegong.presentation.base.UiState
-import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Event
+import com.ssafy.neegongnaegong.presentation.group.list.notice.NoticeDetailContract.Effect
 import kotlinx.collections.immutable.PersistentList
 
 class VoteDetailContract {
@@ -33,6 +33,14 @@ class VoteDetailContract {
         data object OnConfirmAddOption : Event
 
         data object OnClickPopBackStackButton : Event
+
+        data object OnDismissPopUp : Event
+
+        data object OnTogglePopup : Event
+
+        data object OnDeleteVote : Event
+
+        data object OnEditVote : Event
     }
 
     enum class VoteOptions(val option: String, val description: String) {
@@ -60,6 +68,7 @@ class VoteDetailContract {
         val castMode: Boolean,
         val addOptionMode: Boolean,
         val newOption: String,
+        val showPopup: Boolean,
     ) : UiState
 
     sealed interface Effect : UiEffect {
@@ -69,5 +78,7 @@ class VoteDetailContract {
             val title: String,
             val votedMemberInfo: List<StudyGroupVoteStatusInfo.VotedMemberInfo>,
         ) : Effect
+
+        data object NavigateToSubTab : Effect
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailScreen.kt
@@ -7,27 +7,21 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -53,6 +47,7 @@ import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupVoteDetailInfo
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupVoteStatusInfo
 import com.ssafy.neegongnaegong.presentation.component.TopAppBar
+import com.ssafy.neegongnaegong.presentation.group.list.component.PopupMenu
 import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect.NavigateToBackStack
 import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect.NavigateToSubTab
 import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect.NavigateToVotedPersonList
@@ -151,16 +146,14 @@ fun VoteDetailRoute(
                     },
                 )
             },
-            onClickAddOption = {
-                viewModel.setEvent(OnClickAddOption)
-            },
+            onClickAddOption = { viewModel.setEvent(OnClickAddOption) },
             onChangeNewOption = { viewModel.setEvent(OnChangeNewOption(it)) },
             onCancelNewOption = { viewModel.setEvent(OnCancelAddOption) },
             onConfirmNewOption = { viewModel.setEvent(OnConfirmAddOption) },
             onClickPopup = { viewModel.setEvent(OnTogglePopup) },
             onDismissPopup = { viewModel.setEvent(OnDismissPopUp) },
             onClickDeleteVote = { viewModel.setEvent(OnDeleteVote) },
-            onClickEditNotice = { viewModel.setEvent(OnEditVote) },
+            onClickEditVote = { viewModel.setEvent(OnEditVote) },
         )
     }
 }
@@ -190,7 +183,7 @@ private fun VoteDetailScreen(
     onClickPopup: () -> Unit,
     onDismissPopup: () -> Unit,
     onClickDeleteVote: () -> Unit,
-    onClickEditNotice: () -> Unit,
+    onClickEditVote: () -> Unit,
 ) {
     Column(
         modifier =
@@ -271,57 +264,13 @@ private fun VoteDetailScreen(
                             style = NeeGongNaeGongTheme.typography.titleLarge,
                             color = NeeGongNaeGongTheme.colorScheme.primaryText,
                         )
-
-                        Box {
-                            IconButton(
-                                modifier = Modifier.wrapContentSize(),
-                                onClick = onClickPopup,
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.MoreVert,
-                                    contentDescription = "더보기 아이콘",
-                                    tint = NeeGongNaeGongTheme.colorScheme.primaryText,
-                                )
-                            }
-                            DropdownMenu(
-                                expanded = showPopup,
-                                onDismissRequest = onDismissPopup,
-                                containerColor = NeeGongNaeGongTheme.colorScheme.background,
-                            ) {
-                                DropdownMenuItem(
-                                    text = {
-                                        Text(
-                                            modifier =
-                                                Modifier
-                                                    .fillMaxWidth()
-                                                    .wrapContentWidth(Alignment.CenterHorizontally),
-                                            text = "삭제하기",
-                                            style = NeeGongNaeGongTheme.typography.labelMedium,
-                                            color = NeeGongNaeGongTheme.colorScheme.primaryText,
-                                            overflow = TextOverflow.Ellipsis,
-                                        )
-                                    },
-                                    contentPadding = PaddingValues(0.dp),
-                                    onClick = onClickDeleteVote,
-                                )
-                                DropdownMenuItem(
-                                    text = {
-                                        Text(
-                                            modifier =
-                                                Modifier
-                                                    .fillMaxWidth()
-                                                    .wrapContentWidth(Alignment.CenterHorizontally),
-                                            text = "수정하기",
-                                            style = NeeGongNaeGongTheme.typography.labelMedium,
-                                            color = NeeGongNaeGongTheme.colorScheme.primaryText,
-                                            overflow = TextOverflow.Ellipsis,
-                                        )
-                                    },
-                                    contentPadding = PaddingValues(0.dp),
-                                    onClick = onClickEditNotice,
-                                )
-                            }
-                        }
+                        PopupMenu(
+                            showPopup = showPopup,
+                            onClickPopup = onClickPopup,
+                            onDismissPopup = onDismissPopup,
+                            onClickDeleteMenu = onClickDeleteVote,
+                            onClickEditMenu = onClickEditVote,
+                        )
                     }
                     if (voteOptions.isNotEmpty()) {
                         Text(
@@ -529,7 +478,7 @@ private fun PreviewVoteDetailScreen() {
             onCancelNewOption = {},
             onConfirmNewOption = {},
             onClickPopup = {},
-            onClickEditNotice = {},
+            onClickEditVote = {},
             onClickDeleteVote = {},
             onDismissPopup = {},
         )
@@ -582,7 +531,7 @@ private fun PreviewVoteDetailScreenCastMode() {
             onCancelNewOption = {},
             onConfirmNewOption = {},
             onClickPopup = {},
-            onClickEditNotice = {},
+            onClickEditVote = {},
             onClickDeleteVote = {},
             onDismissPopup = {},
         )

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -202,7 +203,7 @@ private fun VoteDetailScreen(
                 modifier =
                     Modifier
                         .size(50.dp)
-                        .clip(RoundedCornerShape(10.dp)),
+                        .clip(CircleShape),
                 imageOptions =
                     ImageOptions(
                         contentScale = ContentScale.Crop,
@@ -217,7 +218,7 @@ private fun VoteDetailScreen(
                         modifier =
                             Modifier
                                 .size(100.dp)
-                                .clip(RoundedCornerShape(10.dp)),
+                                .clip(CircleShape),
                         contentScale = ContentScale.Crop,
                     )
                 },

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailScreen.kt
@@ -7,21 +7,27 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -47,6 +53,22 @@ import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupVoteDetailInfo
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupVoteStatusInfo
 import com.ssafy.neegongnaegong.presentation.component.TopAppBar
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect.NavigateToBackStack
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect.NavigateToSubTab
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect.NavigateToVotedPersonList
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.CastVote
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnCancelAddOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnChangeNewOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnClickAddOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnClickPopBackStackButton
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnClickVotedPersonList
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnConfirmAddOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnDeleteVote
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnDismissPopUp
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnEditVote
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnTogglePopup
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.SelectOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.ToggleCastMode
 import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.VoteOptions
 import com.ssafy.neegongnaegong.presentation.group.list.vote.component.OptionButton
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
@@ -60,21 +82,22 @@ fun VoteDetailRoute(
     viewModel: VoteDetailViewModel = hiltViewModel(backStackEntry),
     navigateToVotedPersonList: (title: String, votedMemberInfo: List<StudyGroupVoteStatusInfo.VotedMemberInfo>) -> Unit,
     popBackStack: () -> Boolean,
+    navigateToSubTab: () -> Unit,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collect {
             when (it) {
-                VoteDetailContract.Effect.NavigateToBackStack -> {
-                    popBackStack()
-                }
+                NavigateToBackStack -> popBackStack()
 
-                is VoteDetailContract.Effect.NavigateToVotedPersonList ->
+                is NavigateToVotedPersonList ->
                     navigateToVotedPersonList(
                         it.title,
                         it.votedMemberInfo,
                     )
+
+                NavigateToSubTab -> navigateToSubTab()
             }
         }
     }
@@ -87,7 +110,7 @@ fun VoteDetailRoute(
                     color = NeeGongNaeGongTheme.colorScheme.primaryText,
                 )
             },
-            onNavigationClick = { viewModel.setEvent(VoteDetailContract.Event.OnClickPopBackStackButton) },
+            onNavigationClick = { viewModel.setEvent(OnClickPopBackStackButton) },
         )
         VoteDetailScreen(
             userName = state.userName,
@@ -95,6 +118,7 @@ fun VoteDetailRoute(
             progressTime = state.progressTime,
             voteTitle = state.voteTitle,
             state = state.state,
+            showPopup = state.showPopup,
             selected = state.selected,
             voteOptions = state.voteOptions,
             voteItems = state.voteItems,
@@ -104,7 +128,7 @@ fun VoteDetailRoute(
             newOptionTitle = state.newOption,
             onClickOption = { optionId, optionName ->
                 viewModel.setEvent(
-                    VoteDetailContract.Event.SelectOption(
+                    SelectOption(
                         optionId,
                         optionName,
                     ),
@@ -112,7 +136,7 @@ fun VoteDetailRoute(
             },
             onClickShowPersonList = { title: String, votedMemberInfos: List<StudyGroupVoteStatusInfo.VotedMemberInfo> ->
                 viewModel.setEvent(
-                    VoteDetailContract.Event.OnClickVotedPersonList(
+                    OnClickVotedPersonList(
                         title,
                         votedMemberInfos,
                     ),
@@ -121,29 +145,34 @@ fun VoteDetailRoute(
             onCastVote = {
                 viewModel.setEvent(
                     if (state.castMode) {
-                        VoteDetailContract.Event.CastVote
+                        CastVote
                     } else {
-                        VoteDetailContract.Event.ToggleCastMode
+                        ToggleCastMode
                     },
                 )
             },
             onClickAddOption = {
-                viewModel.setEvent(VoteDetailContract.Event.OnClickAddOption)
+                viewModel.setEvent(OnClickAddOption)
             },
-            onChangeNewOption = { viewModel.setEvent(VoteDetailContract.Event.OnChangeNewOption(it)) },
-            onCancelNewOption = { viewModel.setEvent(VoteDetailContract.Event.OnCancelAddOption) },
-            onConfirmNewOption = { viewModel.setEvent(VoteDetailContract.Event.OnConfirmAddOption) },
+            onChangeNewOption = { viewModel.setEvent(OnChangeNewOption(it)) },
+            onCancelNewOption = { viewModel.setEvent(OnCancelAddOption) },
+            onConfirmNewOption = { viewModel.setEvent(OnConfirmAddOption) },
+            onClickPopup = { viewModel.setEvent(OnTogglePopup) },
+            onDismissPopup = { viewModel.setEvent(OnDismissPopUp) },
+            onClickDeleteVote = { viewModel.setEvent(OnDeleteVote) },
+            onClickEditNotice = { viewModel.setEvent(OnEditVote) },
         )
     }
 }
 
 @Composable
-fun VoteDetailScreen(
+private fun VoteDetailScreen(
     userName: String,
     userProfileImg: String,
     progressTime: String,
     voteTitle: String,
     state: Boolean,
+    showPopup: Boolean,
     selected: PersistentList<StudyGroupVoteDetailInfo.VoteValue>,
     voteOptions: PersistentList<VoteOptions>,
     voteItems: PersistentList<StudyGroupVoteStatusInfo>,
@@ -158,6 +187,10 @@ fun VoteDetailScreen(
     onChangeNewOption: (String) -> Unit,
     onCancelNewOption: () -> Unit,
     onConfirmNewOption: () -> Unit,
+    onClickPopup: () -> Unit,
+    onDismissPopup: () -> Unit,
+    onClickDeleteVote: () -> Unit,
+    onClickEditNotice: () -> Unit,
 ) {
     Column(
         modifier =
@@ -166,7 +199,10 @@ fun VoteDetailScreen(
                 .padding(horizontal = NeeGongNaeGongTheme.paddingScheme.sp2),
         verticalArrangement = Arrangement.spacedBy(NeeGongNaeGongTheme.paddingScheme.sp4),
     ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(NeeGongNaeGongTheme.paddingScheme.sp2)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(NeeGongNaeGongTheme.paddingScheme.sp2),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             GlideImage(
                 imageModel = { userProfileImg },
                 loading = { CircularProgressIndicator() },
@@ -227,13 +263,66 @@ fun VoteDetailScreen(
                     modifier = Modifier.fillMaxWidth(),
                     verticalArrangement = Arrangement.spacedBy(NeeGongNaeGongTheme.paddingScheme.sp2),
                 ) {
-                    Text(
-                        modifier = Modifier.fillMaxWidth(),
-                        text = voteTitle,
-                        overflow = TextOverflow.Ellipsis,
-                        style = NeeGongNaeGongTheme.typography.titleLarge,
-                        color = NeeGongNaeGongTheme.colorScheme.primaryText,
-                    )
+                    Row(horizontalArrangement = Arrangement.SpaceBetween) {
+                        Text(
+                            modifier = Modifier.weight(1F),
+                            text = voteTitle,
+                            overflow = TextOverflow.Ellipsis,
+                            style = NeeGongNaeGongTheme.typography.titleLarge,
+                            color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                        )
+
+                        Box {
+                            IconButton(
+                                modifier = Modifier.wrapContentSize(),
+                                onClick = onClickPopup,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.MoreVert,
+                                    contentDescription = "더보기 아이콘",
+                                    tint = NeeGongNaeGongTheme.colorScheme.primaryText,
+                                )
+                            }
+                            DropdownMenu(
+                                expanded = showPopup,
+                                onDismissRequest = onDismissPopup,
+                                containerColor = NeeGongNaeGongTheme.colorScheme.background,
+                            ) {
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            modifier =
+                                                Modifier
+                                                    .fillMaxWidth()
+                                                    .wrapContentWidth(Alignment.CenterHorizontally),
+                                            text = "삭제하기",
+                                            style = NeeGongNaeGongTheme.typography.labelMedium,
+                                            color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    },
+                                    contentPadding = PaddingValues(0.dp),
+                                    onClick = onClickDeleteVote,
+                                )
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            modifier =
+                                                Modifier
+                                                    .fillMaxWidth()
+                                                    .wrapContentWidth(Alignment.CenterHorizontally),
+                                            text = "수정하기",
+                                            style = NeeGongNaeGongTheme.typography.labelMedium,
+                                            color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    },
+                                    contentPadding = PaddingValues(0.dp),
+                                    onClick = onClickEditNotice,
+                                )
+                            }
+                        }
+                    }
                     if (voteOptions.isNotEmpty()) {
                         Text(
                             modifier = Modifier.fillMaxWidth(),
@@ -401,7 +490,7 @@ fun VoteDetailScreen(
 
 @Composable
 @NeeGongNaeGongPreviews
-fun PreviewVoteDetailScreen() {
+private fun PreviewVoteDetailScreen() {
     NeeGongNaeGongTheme {
         VoteDetailScreen(
             userName = "",
@@ -409,6 +498,7 @@ fun PreviewVoteDetailScreen() {
             progressTime = "",
             voteTitle = "가능한 날",
             state = false,
+            showPopup = false,
             voteOptions = persistentListOf(VoteOptions.IS_SECRET, VoteOptions.IS_MULTIPLE),
             voteItems =
                 persistentListOf(
@@ -438,13 +528,17 @@ fun PreviewVoteDetailScreen() {
             onChangeNewOption = {},
             onCancelNewOption = {},
             onConfirmNewOption = {},
+            onClickPopup = {},
+            onClickEditNotice = {},
+            onClickDeleteVote = {},
+            onDismissPopup = {},
         )
     }
 }
 
 @Composable
 @NeeGongNaeGongPreviews
-fun PreviewVoteDetailScreenCastMode() {
+private fun PreviewVoteDetailScreenCastMode() {
     NeeGongNaeGongTheme {
         VoteDetailScreen(
             userName = "",
@@ -452,6 +546,7 @@ fun PreviewVoteDetailScreenCastMode() {
             progressTime = "",
             voteTitle = "가능한 날",
             state = true,
+            showPopup = false,
             voteOptions =
                 persistentListOf(
                     VoteOptions.IS_SECRET,
@@ -486,6 +581,10 @@ fun PreviewVoteDetailScreenCastMode() {
             onChangeNewOption = {},
             onCancelNewOption = {},
             onConfirmNewOption = {},
+            onClickPopup = {},
+            onClickEditNotice = {},
+            onClickDeleteVote = {},
+            onDismissPopup = {},
         )
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailViewModel.kt
@@ -6,10 +6,28 @@ import androidx.navigation.toRoute
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupVoteDetailInfo
 import com.ssafy.neegongnaegong.domain.usecase.studygroup.AddNewVoteOptionUseCase
 import com.ssafy.neegongnaegong.domain.usecase.studygroup.CastVoteUseCase
+import com.ssafy.neegongnaegong.domain.usecase.studygroup.DeleteVoteDetailUseCase
 import com.ssafy.neegongnaegong.domain.usecase.studygroup.GetVoteDetailUseCase
 import com.ssafy.neegongnaegong.presentation.base.BaseViewModel
 import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect.NavigateToBackStack
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect.NavigateToSubTab
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Effect.NavigateToVotedPersonList
 import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.CastVote
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.InvalidAccess
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnCancelAddOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnChangeNewOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnClickAddOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnClickPopBackStackButton
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnClickVotedPersonList
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnConfirmAddOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnDeleteVote
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnDismissPopUp
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnEditVote
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.OnTogglePopup
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.SelectOption
+import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.Event.ToggleCastMode
 import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.State
 import com.ssafy.neegongnaegong.presentation.group.list.vote.VoteDetailContract.VoteOptions
 import com.ssafy.neegongnaegong.presentation.navigation.AppNavigation
@@ -27,6 +45,7 @@ class VoteDetailViewModel
         getVoteDetailUseCase: GetVoteDetailUseCase,
         private val addNewVoteOptionUseCase: AddNewVoteOptionUseCase,
         private val castVoteUseCase: CastVoteUseCase,
+        private val deleteVoteDetailUseCase: DeleteVoteDetailUseCase,
     ) :
     BaseViewModel<Event, State, Effect>() {
         override fun createInitialState(): State =
@@ -43,15 +62,16 @@ class VoteDetailViewModel
                 castMode = false,
                 addOptionMode = false,
                 newOption = "",
+                showPopup = false,
             )
 
         override fun handleEvent(event: Event) {
             when (event) {
-                Event.InvalidAccess -> {
-                    setEffect { Effect.NavigateToBackStack }
+                InvalidAccess -> {
+                    setEffect { NavigateToBackStack }
                 }
 
-                is Event.SelectOption -> {
+                is SelectOption -> {
                     val selectedItem =
                         StudyGroupVoteDetailInfo.VoteValue(
                             event.voteItemId,
@@ -86,7 +106,7 @@ class VoteDetailViewModel
                     }
                 }
 
-                is Event.CastVote -> {
+                is CastVote -> {
                     viewModelScope.launch {
                         if (uiState.value.selected != uiState.value.voteValues) {
                             castVoteUseCase(
@@ -102,19 +122,19 @@ class VoteDetailViewModel
                     }
                 }
 
-                is Event.OnClickVotedPersonList -> {
-                    setEffect { Effect.NavigateToVotedPersonList(event.title, event.votedMemberInfo) }
+                is OnClickVotedPersonList -> {
+                    setEffect { NavigateToVotedPersonList(event.title, event.votedMemberInfo) }
                 }
 
-                Event.ToggleCastMode -> setState { copy(castMode = !castMode) }
+                ToggleCastMode -> setState { copy(castMode = !castMode) }
 
-                Event.OnClickAddOption -> setState { copy(addOptionMode = true) }
+                OnClickAddOption -> setState { copy(addOptionMode = true) }
 
-                is Event.OnChangeNewOption -> setState { copy(newOption = event.optionTitle) }
+                is OnChangeNewOption -> setState { copy(newOption = event.optionTitle) }
 
-                Event.OnCancelAddOption -> setState { copy(addOptionMode = false, newOption = "") }
+                OnCancelAddOption -> setState { copy(addOptionMode = false, newOption = "") }
 
-                Event.OnConfirmAddOption -> {
+                OnConfirmAddOption -> {
                     viewModelScope.launch {
                         addNewVoteOptionUseCase(
                             groupId,
@@ -126,7 +146,28 @@ class VoteDetailViewModel
                     }
                 }
 
-                Event.OnClickPopBackStackButton -> setEffect { Effect.NavigateToBackStack }
+                OnClickPopBackStackButton -> setEffect { NavigateToBackStack }
+                OnDeleteVote ->
+                    viewModelScope.launch {
+                        deleteVoteDetailUseCase(
+                            studyGroupId = groupId,
+                            voteId = voteId,
+                        ).safeCollect {
+                            showSuccessMessage("투표를 삭제했습니다!")
+                            // SubTab으로 돌아가기 전 PopUp 메뉴 숨기고 이동
+                            // setState로 처리하지 않으니 Navigation 될 때 잠깐 살아있는 현상 있었음
+                            setState { copy(showPopup = false) }
+                            setEffect { NavigateToSubTab }
+                        }
+                    }
+
+                OnDismissPopUp -> setState { copy(showPopup = false) }
+                OnEditVote -> {
+                    showWarningMessage("아직 추가되지 않은 기능이에요! 삭제를 이용해주세요")
+                    setState { copy(showPopup = false) }
+                }
+
+                OnTogglePopup -> setState { copy(showPopup = !showPopup) }
             }
         }
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
@@ -87,6 +87,11 @@ object AppNavigation {
 
             @Serializable
             sealed interface SubTab : Studies {
+                enum class SubTabMenu(val index: Int) {
+                    NoticeTab(0),
+                    VoteTab(1),
+                }
+
                 @Serializable
                 data class Main(val startTab: Int, val groupId: Long) : SubTab
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.json.Json
  */
 fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
     navigation<AppNavigation.Tab.Studies>(
-        startDestination = AppNavigation.Screen.Studies.SubTab.Main(0, 6),
+        startDestination = AppNavigation.Screen.Studies.Main,
     ) {
         composable<AppNavigation.Screen.Studies.Main> {
             StudiesRoute(

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
@@ -182,11 +182,20 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
         }
 
         composable<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail> {
+            val groupId =
+                it.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>().groupId
             NoticeDetailRoute(
                 backStackEntry = it,
                 viewModel = hiltViewModel(it),
+                popBackStack = navController::popBackStack,
             ) {
-                navController.popBackStack()
+                navController.navigate(
+                    AppNavigation.Screen.Studies.SubTab.Main(startTab = 0, groupId = groupId),
+                ) {
+                    popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
+                        inclusive = true
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.json.Json
  */
 fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
     navigation<AppNavigation.Tab.Studies>(
-        startDestination = AppNavigation.Screen.Studies.Main,
+        startDestination = AppNavigation.Screen.Studies.SubTab.Main(0, 6),
     ) {
         composable<AppNavigation.Screen.Studies.Main> {
             StudiesRoute(
@@ -190,7 +190,10 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
                 popBackStack = navController::popBackStack,
             ) {
                 navController.navigate(
-                    AppNavigation.Screen.Studies.SubTab.Main(startTab = 0, groupId = groupId),
+                    AppNavigation.Screen.Studies.SubTab.Main(
+                        startTab = AppNavigation.Screen.Studies.SubTab.SubTabMenu.NoticeTab.index,
+                        groupId = groupId,
+                    ),
                 ) {
                     popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
                         inclusive = true
@@ -200,6 +203,8 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
         }
 
         composable<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail> {
+            val groupId =
+                it.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail>().groupId
             VoteDetailRoute(
                 backStackEntry = it,
                 viewModel = hiltViewModel(it),
@@ -209,8 +214,18 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
                         AppNavigation.Screen.Studies.SubTab.Screen.VotedPerson(title, json),
                     )
                 },
+                popBackStack = navController::popBackStack,
             ) {
-                navController.popBackStack()
+                navController.navigate(
+                    AppNavigation.Screen.Studies.SubTab.Main(
+                        startTab = AppNavigation.Screen.Studies.SubTab.SubTabMenu.VoteTab.index,
+                        groupId = groupId,
+                    ),
+                ) {
+                    popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
+                        inclusive = true
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## 📌 연결된 이슈
- #112 

### ✅ 작업 내용
- 투표 삭제 API 연결 및 관련 Event 등 구현
- 공지 삭제 API 연결 및 관련 Event 등 구현
- 공지와 투표 상세 화면에서 삭제, 수정을 위한 PopupMenu Component 생성
- 공지 상세 API Response 값 중 쓰지 않는 userProfileImage 속성 삭제
- SubTab의 진입접 관련해서 SubTabMenu라는 EnumClass 생성

### 📷 관련 이미지(영상)
|공지 삭제, 수정|투표 삭제 수정|
|:--:|:--:|
|<video src="https://github.com/user-attachments/assets/f57f0ac2-1206-4df9-bdc0-af3ae7b8b0e5" alt="시연" controls></video>|<video width="400" alt="시연" src = "https://github.com/user-attachments/assets/7df48720-5017-4abf-a95a-285f8479b12e" controls >|

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
- 모든 유저에게 Popup 메뉴가 보입니다, 단 권한이 없는 사람이 누를 경우 서버에서 에러를 반환합니다 (아직 제대로 그룹 내에 다른 멤버가 쓴 공지나, 투표가 없어서 권한 없는 글 삭제 테스트 같은 건 하지 못했습니다.

- SubTab의 Main에 접근할 때 HorizontalPager의 인덱스로 설정할 `startIdx`를 받게 되는데
  그냥 정수형의 값을 받아왔기 때문에 혹여 잘못된 값을 넣을까 SubTabmenu라는 Enum Class를 만들었습니다
  안정성을 생각한다면 SubTabMenu 자체를 받는게 좋을 거 같긴 하지만 지금 다른 브랜치 등에서도 이것 관련해서 작업을 하는 것으로 알고 있어 일단은 Enum 내 index 속성을 던지게 했습니다 관련해서 더 나은 의견 있으시면 알려주세용
  
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 