### PR TITLE
에러 리포트 설정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt.plugin)
     alias(libs.plugins.google.services)
+    alias(libs.plugins.crashlytics)
     alias(libs.plugins.serialization)
     alias(libs.plugins.ktlint)
     alias(libs.plugins.detekt)
@@ -127,4 +128,7 @@ dependencies {
     // Room
     implementation(libs.androidx.room.paging)
     ksp(libs.androidx.room.compiler)
+
+    // firebase
+    implementation(libs.firebase.crashlytics)
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/ApplicationClass.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/ApplicationClass.kt
@@ -1,7 +1,17 @@
 package com.ssafy.neegongnaegong
 
 import android.app.Application
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class ApplicationClass : Application()
+class ApplicationClass : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        if (BuildConfig.DEBUG) {
+            Firebase.crashlytics.isCrashlyticsCollectionEnabled = false
+        }
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/base/LoginStatusViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/base/LoginStatusViewModel.kt
@@ -2,37 +2,51 @@ package com.ssafy.neegongnaegong.presentation.base
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
+import com.ssafy.neegongnaegong.domain.usecase.user.GetMyProfileUseCase
 import com.ssafy.neegongnaegong.presentation.util.AuthManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class LoginStatusViewModel @Inject constructor(
-    private val authManager: AuthManager
-) : ViewModel() {
-    data class State(val isLoading: Boolean, val isLoginSuccess: Boolean)
+class LoginStatusViewModel
+    @Inject
+    constructor(
+        private val authManager: AuthManager,
+        private val getMyProfileUseCase: GetMyProfileUseCase,
+    ) : ViewModel() {
+        data class State(val isLoading: Boolean, val isLoginSuccess: Boolean)
 
-    private val isLoading = MutableStateFlow(true)
+        private val isLoading = MutableStateFlow(true)
 
-    /**
-     * loading이 되었는지와 login이 성공했는지를 관리하는 상태
-     */
-    val state = combine(isLoading, authManager.isValid) { isLoading, isValid ->
-        State(isLoading = isLoading, isLoginSuccess = isValid)
-    }.stateIn(
-        viewModelScope,
-        SharingStarted.Eagerly,
-        State(isLoading = true, isLoginSuccess = false)
-    )
+        /**
+         * loading이 되었는지와 login이 성공했는지를 관리하는 상태
+         */
+        val state =
+            combine(isLoading, authManager.isValid) { isLoading, isValid ->
+                if (isValid) {
+                    Firebase.crashlytics.setUserId(getMyProfileUseCase().first().id.toString())
+                } else {
+                    Firebase.crashlytics.setUserId("로그인이 확인되지 않은 사용자")
+                }
 
-    init {
-        viewModelScope.launch {
-            authManager.tryAuth { isLoading.value = it }
+                State(isLoading = isLoading, isLoginSuccess = isValid)
+            }.stateIn(
+                viewModelScope,
+                SharingStarted.Eagerly,
+                State(isLoading = true, isLoginSuccess = false),
+            )
+
+        init {
+            viewModelScope.launch {
+                authManager.tryAuth { isLoading.value = it }
+            }
         }
     }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.hilt.plugin) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.crashlytics) apply false
     alias(libs.plugins.serialization) apply false
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.detekt)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ ktlint = "12.2.0"
 detekt = "1.23.8"
 #room
 roomPaging = "2.7.1"
+#crasylytics
+crashlytics = "3.0.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -76,6 +78,7 @@ gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref 
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "credentials" }
 androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
 firebase-auth = { module = "com.google.firebase:firebase-auth" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics"}
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
 
@@ -114,6 +117,7 @@ google-services = {id = "com.google.gms.google-services", version= "4.4.2"}
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt"}
+crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics"}
 
 
 [bundles]


### PR DESCRIPTION
## 📌 연결된 이슈
- #139 

### ✅ 작업 내용
- Firebase Crashlytics 연동하여 Crash 등 앱 장애 추적

### 📷 관련 이미지(영상)

|UserID 키 세팅|예시 에러 코드|
|:--:|:--:|
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/a87e6d5e-ab16-43ce-a1db-8c97a0d20fe9" />|![image](https://github.com/user-attachments/assets/b9d4a675-4822-4665-b452-7103098c3e99)|

|분류|사진|
|:--:|:--:|
|**Crash Report 메인 화면**|![image](https://github.com/user-attachments/assets/78450e1a-035f-4f5f-9ec0-6a287c0d82f5)| 
|**Crash Stack Trace**|![image](https://github.com/user-attachments/assets/ace60272-5e0a-4cce-ae48-4f1f8bc07b88)|
|**Custom Key 정보**|![image](https://github.com/user-attachments/assets/b87b2bc8-c9a4-46d3-92b6-8f35e9c69d70)|
|**Log 정보**|![image](https://github.com/user-attachments/assets/ca19936e-3a5d-4319-8177-df575ebc74fc)|
|**에러 당시 Device 상태 정보**|![image](https://github.com/user-attachments/assets/f54e5d8b-81ef-482b-8956-0ef06fbb67b3)|

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
- 예시 에러 코드에 있는 것처럼 `throw`가 발생했을 때 당시 관련 정보를 받아볼 수 있습니다
- `log`를 찍어두면, 아래 `log` 정보처럼 사용자가 앱을 사용하던 흐름까지 구체적으로 알 수 있어 버그 추적 시 더 명확하게 알 수 있어서 `log`를 적극 사용하는 것도 고려해야 할 것 같습니다
- 현재 `userId`를 키 값으로 설정해서 어떤 회원에게서 에러가 발생한 것인지 확인할 수 있도록 했습니다
- 현재는 `Debug` 모드로 빌드 시에는 `Crashlytics`가 동작하지 않도록 설정해놨습니다
- `crashlytics`를 `Object` 같은 것으로 따로 빼둘까 싶었는데 그럴 필요까지는 없을 거 같아서 일단 놔뒀습니다