### PR TITLE
디바이스별 Preview 대응

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/ui/theme/NeeGongNaeGongPreviews.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/ui/theme/NeeGongNaeGongPreviews.kt
@@ -3,16 +3,113 @@ package com.ssafy.neegongnaegong.presentation.ui.theme
 import android.content.res.Configuration
 import androidx.compose.ui.tooling.preview.Preview
 
+/**
+ * Phone, Foldable, Tablet에 대한 세로/가로, 라이트/다크 모드를
+ * 모두 포함하는 최종 미리보기 어노테이션입니다. (총 12개)
+ */
 @Preview(
-    name = "Light Mode",
+    name = "01. Phone - Portrait Light",
+    group = "Phone",
     showBackground = true,
     uiMode = Configuration.UI_MODE_NIGHT_NO,
     backgroundColor = 0xFFFFFFFF,
+    device = PHONE_PORTRAIT,
 )
 @Preview(
-    name = "Dark Mode",
+    name = "02. Phone - Portrait Dark",
+    group = "Phone",
     showBackground = true,
     uiMode = Configuration.UI_MODE_NIGHT_YES,
     backgroundColor = 0xFF000000,
+    device = PHONE_PORTRAIT,
+)
+@Preview(
+    name = "03. Phone - Landscape Light",
+    group = "Phone",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    backgroundColor = 0xFFFFFFFF,
+    device = PHONE_LANDSCAPE,
+)
+@Preview(
+    name = "04. Phone - Landscape Dark",
+    group = "Phone",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    backgroundColor = 0xFF000000,
+    device = PHONE_LANDSCAPE,
+)
+@Preview(
+    name = "05. Foldable - Portrait Light",
+    group = "Foldable",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    backgroundColor = 0xFFFFFFFF,
+    device = FOLDABLE_PORTRAIT,
+)
+@Preview(
+    name = "06. Foldable - Portrait Dark",
+    group = "Foldable",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    backgroundColor = 0xFF000000,
+    device = FOLDABLE_PORTRAIT,
+)
+@Preview(
+    name = "07. Foldable - Landscape Light",
+    group = "Foldable",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    backgroundColor = 0xFFFFFFFF,
+    device = FOLDABLE_LANDSCAPE,
+)
+@Preview(
+    name = "08. Foldable - Landscape Dark",
+    group = "Foldable",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    backgroundColor = 0xFF000000,
+    device = FOLDABLE_LANDSCAPE,
+)
+@Preview(
+    name = "09. Tablet - Portrait Light",
+    group = "Tablet",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    backgroundColor = 0xFFFFFFFF,
+    device = TABLET_PORTRAIT,
+)
+@Preview(
+    name = "10. Tablet - Portrait Dark",
+    group = "Tablet",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    backgroundColor = 0xFF000000,
+    device = TABLET_PORTRAIT,
+)
+@Preview(
+    name = "11. Tablet - Landscape Light",
+    group = "Tablet",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    backgroundColor = 0xFFFFFFFF,
+    device = TABLET_LANDSCAPE,
+)
+@Preview(
+    name = "12. Tablet - Landscape Dark",
+    group = "Tablet",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    backgroundColor = 0xFF000000,
+    device = TABLET_LANDSCAPE,
 )
 annotation class NeeGongNaeGongPreviews
+
+private const val PHONE_PORTRAIT = "spec:id=reference_phone,shape=Normal,width=411dp,height=891dp,,dpi=420"
+private const val PHONE_LANDSCAPE = "spec:id=reference_phone,shape=Normal,width=891dp,height=411dp,dpi=420,orientation=landscape"
+private const val FOLDABLE_PORTRAIT =
+    "spec:id=reference_foldable,shape=Normal,width=673dp,height=841dp,dpi=420"
+private const val FOLDABLE_LANDSCAPE =
+    "spec:id=reference_foldable,shape=Normal,width=841dp,height=673dp,dpi=420,orientation=landscape"
+private const val TABLET_PORTRAIT = "spec:width=853dp,height=1365dp,dpi=276"
+private const val TABLET_LANDSCAPE = "spec:width=1365dp,height=853dp,dpi=276,orientation=landscape"


### PR DESCRIPTION
## 📌 연결된 이슈
- #152 

### ✅ 작업 내용
- 일반 스마트폰, 폴드, 태블릿에 대해서 Preview를 생성
- 가로, 세로 모드에 대해 각각의 디바이스에 대해서 별도의 Preview 생성

### 📷 관련 이미지(영상)
|일반 스마트폰|폴더블|태블릿|
|:--:|:--:|:--:|
|<img width="221" alt="가로세로" src="https://github.com/user-attachments/assets/5564cf4c-5c12-4e4e-ad35-6eee2ecf2292" />|<img width="326" alt="폴더블" src="https://github.com/user-attachments/assets/04a7c105-5c2c-4703-8e55-6df7a703a155" />|<img width="361" alt="태블릿" src="https://github.com/user-attachments/assets/7e181ba4-8d91-4905-a8d1-6157b9d46be9" />|

|그룹 선택|
|:--:|
|<img width="188" alt="그룹" src="https://github.com/user-attachments/assets/88dc268d-03c6-4fcf-9882-26bfc9e11f5d" />|

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
- 기본적으로 Group이 All로 선택되어 있는데, 이러면 총 12개의 Preview가 한꺼번에 보여서 난잡하실 수 있습니다
- Group으로 분리해서 `Phone`, `Foldable`, `Table`으로 나눠놨습니다
- 그래서 위 사진처럼 Group으로 분리해서 보면 해당 디바이스의 가로 세로별 주간, 야간모드에 대한 `Preview`만 보실 수 있습니다