### PR TITLE
스터디 상세화면 : 피드에 작성자 추가

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/learningrecord/LearningRecordMapper.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/learningrecord/LearningRecordMapper.kt
@@ -3,8 +3,10 @@ package com.ssafy.neegongnaegong.data.mapper.learningrecord
 import com.ssafy.neegongnaegong.data.mapper.tag.LearningRecordTagMapper.toDomain
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.CreateLearningRecordRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.UpdateLearningRecordRequest
+import com.ssafy.neegongnaegong.data.model.learningrecord.response.AuthorResponse
 import com.ssafy.neegongnaegong.data.model.learningrecord.response.GetLearningRecordDatesByMonthResponse
 import com.ssafy.neegongnaegong.data.model.learningrecord.response.GetLearningRecordResponse
+import com.ssafy.neegongnaegong.domain.model.User
 import com.ssafy.neegongnaegong.domain.model.learning.LearningRecord
 import java.time.LocalDate
 
@@ -33,6 +35,7 @@ internal object LearningRecordMapper {
             startAt = startAt,
             endAt = endAt,
             tags = tags.toDomain(),
+            author = author.toDomain(),
         )
 
     fun List<GetLearningRecordResponse>.toDomain() = map { it.toDomain() }
@@ -42,4 +45,11 @@ internal object LearningRecordMapper {
             val (year, month, day) = dateList
             LocalDate.of(year, month, day)
         }
+
+    fun AuthorResponse.toDomain() =
+        User(
+            id = id,
+            nickname = username,
+            profileImg = profileImg,
+        )
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/learningrecord/response/AuthorResponse.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/learningrecord/response/AuthorResponse.kt
@@ -1,0 +1,7 @@
+package com.ssafy.neegongnaegong.data.model.learningrecord.response
+
+data class AuthorResponse(
+    val id: Long,
+    val username: String,
+    val profileImg: String,
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/learningrecord/response/GetLearningRecordResponse.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/learningrecord/response/GetLearningRecordResponse.kt
@@ -9,6 +9,7 @@ data class GetLearningRecordResponse(
     val startAt: LocalDateTime,
     val endAt: LocalDateTime,
     val tags: List<TagResponse>,
+    val author: AuthorResponse,
     val learningRecordCreatedAt: LocalDateTime,
     val learningRecordModifiedAt: LocalDateTime,
     val cursorCreatedAt: LocalDateTime,

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/learning/LearningRecord.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/learning/LearningRecord.kt
@@ -1,5 +1,6 @@
 package com.ssafy.neegongnaegong.domain.model.learning
 
+import com.ssafy.neegongnaegong.domain.model.User
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -11,6 +12,7 @@ data class LearningRecord(
     val startAt: LocalDateTime,
     val endAt: LocalDateTime,
     val tags: List<Tag>,
+    val author: User,
 ) {
     companion object {
         private val formatter = DateTimeFormatter.ISO_DATE_TIME
@@ -33,6 +35,7 @@ data class LearningRecord(
                         formatter.withZone(ZoneOffset.UTC),
                     ),
                 tags = emptyList(),
+                author = User.default(),
             )
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/preview/personal/PersonalPreviewDataProvider.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/preview/personal/PersonalPreviewDataProvider.kt
@@ -1,5 +1,6 @@
 package com.ssafy.neegongnaegong.domain.model.preview.personal
 
+import com.ssafy.neegongnaegong.domain.model.User
 import com.ssafy.neegongnaegong.domain.model.learning.LearningRecord
 import com.ssafy.neegongnaegong.domain.model.learning.Tag
 import java.time.LocalDateTime
@@ -34,6 +35,12 @@ class PersonalPreviewDataProvider {
             startAt = LocalDateTime.parse("2025-04-14T18:33:02.856Z", formatter),
             endAt = LocalDateTime.parse("2025-04-14T20:33:02.856Z", formatter),
             tags = tagByKo("CS", "네트워크", "Kotlin"),
+            author =
+                User(
+                    id = 0,
+                    nickname = "공부하는 호랑이23",
+                    profileImg = "",
+                ),
         )
 
     fun getStudyRecords(): List<LearningRecord> =
@@ -45,6 +52,7 @@ class PersonalPreviewDataProvider {
                 startAt = LocalDateTime.parse("2025-04-14T04:33:02.856Z", formatter),
                 endAt = LocalDateTime.parse("2025-04-14T06:33:02.856Z", formatter),
                 tags = tagByKo("재테크", "미술"),
+                author = User.default(),
             ),
             LearningRecord(
                 id = 2,
@@ -53,6 +61,7 @@ class PersonalPreviewDataProvider {
                 startAt = LocalDateTime.parse("2025-04-14T06:33:02.856Z", formatter),
                 endAt = LocalDateTime.parse("2025-04-14T08:33:02.856Z", formatter),
                 tags = tagByKo("회계"),
+                author = User.default(),
             ),
             LearningRecord(
                 id = 3,
@@ -61,6 +70,7 @@ class PersonalPreviewDataProvider {
                 startAt = LocalDateTime.parse("2025-04-14T04:33:02.856Z", formatter),
                 endAt = LocalDateTime.parse("2025-04-14T06:33:02.856Z", formatter),
                 tags = tagByKo("CS", "미술"),
+                author = User.default(),
             ),
             LearningRecord(
                 id = 4,
@@ -69,6 +79,7 @@ class PersonalPreviewDataProvider {
                 startAt = LocalDateTime.parse("2025-04-14T04:33:02.856Z", formatter),
                 endAt = LocalDateTime.parse("2025-04-14T06:33:02.856Z", formatter),
                 tags = tagByKo("백엔드", "네트워크"),
+                author = User.default(),
             ),
             LearningRecord(
                 id = 5,
@@ -77,6 +88,7 @@ class PersonalPreviewDataProvider {
                 startAt = LocalDateTime.parse("2025-04-14T04:33:02.856Z", formatter),
                 endAt = LocalDateTime.parse("2025-04-14T06:33:02.856Z", formatter),
                 tags = tagByKo("백엔드"),
+                author = User.default(),
             ),
             LearningRecord(
                 id = 6,
@@ -85,6 +97,7 @@ class PersonalPreviewDataProvider {
                 startAt = LocalDateTime.parse("2025-04-14T04:33:02.856Z", formatter),
                 endAt = LocalDateTime.parse("2025-04-14T06:33:02.856Z", formatter),
                 tags = tagByKo("CS", "네트워크"),
+                author = User.default(),
             ),
             LearningRecord(
                 id = 7,
@@ -93,6 +106,7 @@ class PersonalPreviewDataProvider {
                 startAt = LocalDateTime.parse("2025-04-14T04:33:02.856Z", formatter),
                 endAt = LocalDateTime.parse("2025-04-14T06:33:02.856Z", formatter),
                 tags = tagByKo("CS", "네트워크"),
+                author = User.default(),
             ),
         )
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/StudyContentInfo.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/StudyContentInfo.kt
@@ -1,6 +1,7 @@
 package com.ssafy.neegongnaegong.domain.model.studygroup
 
 import com.ssafy.neegongnaegong.data.mapper.tag.TagInfoMapper.toDomain
+import com.ssafy.neegongnaegong.domain.model.User
 import com.ssafy.neegongnaegong.domain.model.learning.LearningRecord
 import java.time.LocalDateTime
 
@@ -25,4 +26,5 @@ fun StudyContentInfo.toLearningRecord() =
         startAt = startAt,
         endAt = endAt,
         tags = tags.toDomain(),
+        author = User.default(),
     )

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/TopAppBar.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/TopAppBar.kt
@@ -1,5 +1,6 @@
 package com.ssafy.neegongnaegong.presentation.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -41,6 +42,7 @@ fun TopAppBar(
         modifier =
             Modifier
                 .fillMaxWidth()
+                .background(color = NeeGongNaeGongTheme.colorScheme.background)
                 .padding(vertical = 10.dp)
                 .pointerInput(Unit) {}
                 .then(modifier),

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordItem.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordItem.kt
@@ -1,5 +1,6 @@
 package com.ssafy.neegongnaegong.presentation.component.studyrecord
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -9,20 +10,28 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.skydoves.landscapist.glide.GlideImage
+import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.domain.model.learning.LearningRecord
 import com.ssafy.neegongnaegong.domain.model.preview.personal.PersonalPreviewDataProvider
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
@@ -30,9 +39,22 @@ import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
 import com.ssafy.neegongnaegong.presentation.util.toHourMinuteString
 import com.ssafy.neegongnaegong.presentation.util.toTimeString
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun StudyRecordItem(
+    record: LearningRecord,
+    isStudyFeed: Boolean = false,
+    onClick: (Long) -> Unit = {},
+) {
+    if (isStudyFeed) {
+        StudyFeedItem(record, onClick)
+    } else {
+        PersonalRecordItem(record, onClick)
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PersonalRecordItem(
     record: LearningRecord,
     onClick: (Long) -> Unit = {},
 ) {
@@ -41,8 +63,10 @@ fun StudyRecordItem(
             Modifier
                 .fillMaxWidth()
                 .shadow(4.dp, RoundedCornerShape(8.dp))
-                .background(NeeGongNaeGongTheme.colorScheme.recordBackground, RoundedCornerShape(8.dp))
-                .clickable(onClick = { onClick(record.id) })
+                .background(
+                    NeeGongNaeGongTheme.colorScheme.recordBackground,
+                    RoundedCornerShape(8.dp),
+                ).clickable(onClick = { onClick(record.id) })
                 .padding(16.dp),
     ) {
         Column {
@@ -103,10 +127,145 @@ fun StudyRecordItem(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun StudyFeedItem(
+    record: LearningRecord,
+    onClick: (Long) -> Unit = {},
+) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .shadow(4.dp, RoundedCornerShape(8.dp))
+                .background(
+                    NeeGongNaeGongTheme.colorScheme.recordBackground,
+                    RoundedCornerShape(8.dp),
+                ).clickable(onClick = { onClick(record.id) })
+                .padding(vertical = 8.dp, horizontal = 16.dp),
+    ) {
+        Column {
+            // 제목 + 시간
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = record.title.ifBlank { "제목을 설정해주세요." },
+                    style = NeeGongNaeGongTheme.typography.titleMedium.copy(fontSize = 20.sp),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                )
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                Row(
+                    modifier = Modifier,
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .padding(end = 4.dp)
+                                .size(28.dp)
+                                .clip(RoundedCornerShape(14.dp))
+                                .background(NeeGongNaeGongTheme.colorScheme.gray3),
+                    ) {
+                        GlideImage(
+                            imageModel = { record.author.profileImg },
+                            loading = {
+                                Box(modifier = Modifier.matchParentSize()) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.align(Alignment.Center),
+                                        color = NeeGongNaeGongTheme.colorScheme.blue,
+                                    )
+                                }
+                            },
+                            failure = {
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxSize()
+                                            .background(color = NeeGongNaeGongTheme.colorScheme.blue),
+                                ) {
+                                    Image(
+                                        modifier =
+                                            Modifier
+                                                .size(80.dp)
+                                                .align(Alignment.Center),
+                                        painter = painterResource(R.drawable.img_default_profile),
+                                        contentDescription = "이미지 로드 실패",
+                                    )
+                                }
+                            },
+                        )
+                    }
+                }
+
+                Text(
+                    text = record.author.nickname,
+                    style = NeeGongNaeGongTheme.typography.labelMedium,
+                    color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // 내용
+            Text(
+                modifier = Modifier.defaultMinSize(minHeight = 60.dp),
+                text = record.content.ifBlank { "내용을 설정해주세요" },
+                style = NeeGongNaeGongTheme.typography.bodySmall.copy(fontSize = 12.sp),
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
+                color = NeeGongNaeGongTheme.colorScheme.secondaryText,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                // 태그
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    record.tags.forEach { tag ->
+                        Text(
+                            text = "#${tag.koName}",
+                            fontSize = 12.sp,
+                            color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                        )
+                    }
+                }
+                val start = record.startAt.toTimeString()
+                val end = record.endAt.toHourMinuteString()
+                Text(
+                    text = "$start ~ $end",
+                    style =
+                        NeeGongNaeGongTheme.typography.bodySmall.copy(
+                            fontSize = 10.sp,
+                            color = Color.Gray,
+                        ),
+                )
+            }
+        }
+    }
+}
+
 @NeeGongNaeGongPreviews
 @Composable
-fun StudyRecordItemPreview() {
+private fun PreviewPersonalRecordItem() {
     NeeGongNaeGongTheme {
-        StudyRecordItem(record = PersonalPreviewDataProvider().getStudyRecord())
+        PersonalRecordItem(record = PersonalPreviewDataProvider().getStudyRecord())
+    }
+}
+
+@NeeGongNaeGongPreviews
+@Composable
+private fun PreviewStudyFeedItem() {
+    NeeGongNaeGongTheme {
+        StudyFeedItem(record = PersonalPreviewDataProvider().getStudyRecord())
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordItem.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordItem.kt
@@ -137,10 +137,10 @@ private fun StudyFeedItem(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .shadow(4.dp, RoundedCornerShape(8.dp))
+//                .shadow(4.dp, RoundedCornerShape(8.dp))
                 .background(
                     NeeGongNaeGongTheme.colorScheme.recordBackground,
-                    RoundedCornerShape(8.dp),
+                    RoundedCornerShape(4.dp),
                 ).clickable(onClick = { onClick(record.id) })
                 .padding(vertical = 8.dp, horizontal = 16.dp),
     ) {
@@ -227,6 +227,7 @@ private fun StudyFeedItem(
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 // 태그

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordList.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordList.kt
@@ -38,6 +38,7 @@ fun StudyRecordList(
     // paging
     onLoadMore: () -> Unit,
     hasNext: Boolean,
+    isStudyFeed: Boolean = false,
 ) {
     if (learningRecords.isEmpty()) {
         Box(
@@ -92,7 +93,7 @@ fun StudyRecordList(
                 }
 
                 items(recordsForDate) { record ->
-                    StudyRecordItem(record = record, onClick = onClick)
+                    StudyRecordItem(record = record, isStudyFeed = isStudyFeed, onClick = onClick)
                 }
             }
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.ssafy.neegongnaegong.presentation.group.detail
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -107,7 +108,7 @@ private fun StudiesDetailScreen(
     val currentDrawerState = LocalDrawerState.current
     val scope = rememberCoroutineScope()
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize().background(color = NeeGongNaeGongTheme.colorScheme.gray2),
     ) {
         // 커스텀 앱바
         TopAppBar(
@@ -131,7 +132,7 @@ private fun StudiesDetailScreen(
         Column(modifier = Modifier) {
             // 프로필 아이콘 행
             ProfilesSection(
-                modifier = modifier,
+                modifier = Modifier.background(color = NeeGongNaeGongTheme.colorScheme.background),
                 weeklyRankings = weeklyRankings,
                 studyGoalTime = studyGoalTime,
                 onLoadMore = onLoadWeeklyRankings,

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailScreen.kt
@@ -167,6 +167,7 @@ private fun StudiesDetailScreen(
                 hasNext = feedsHasNext,
                 onClick = {},
                 onLoadMore = onLoadFeeds,
+                isStudyFeed = true,
             )
         }
 


### PR DESCRIPTION
## 📌 연결된 이슈
- #160

### ✅ 작업 내용
- 스터디 작성자 추가
  - **author** 라는 새로운 **pram**이 생기면서 domain layer의 `LearningRecord` 리팩토링
- 디자인 변경
  - 기존 박스형 디자인에서 배경색을 달리하여 카드 느낌보다는 **compatc**한 느낌으로 적용(스터디 상세화면에만 적용)
  - 디자인 통일 필요, 색상 통일 필요
  - 박스 크기에 최소 높이 지정 (텍스트 내용이 적게 형성되어 있으면 기존에는 높이가 너무 작아 답답해 보이는 현상 방지)

### 📷 관련 이미지(영상)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/91e533cd-68bf-4f60-895c-6b7e1859812b" />

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)

@Na2te 
close #160