### PR TITLE
FCM 딥링크 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ node_modules/
 .kotlin/errors/errors-1750240286693.log
 .idea/csv-editor.xml
 app/schemas/
+app/neegongnaegong-release.jks
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,19 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        manifestPlaceholders["deepLinkHostName"] =
+            properties.getProperty("DEEP_LINK_HOST")
         buildConfigField("String", "BASE_URL", properties.getProperty("BASE_URL"))
         buildConfigField("String", "GOOGLE_CLIENT_ID", properties.getProperty("GOOGLE_CLIENT_ID"))
+    }
+
+    signingConfigs {
+        create("release") {
+            storeFile = file(properties.getProperty("STORE_FILE"))
+            storePassword = properties.getProperty("STORE_PASSWORD")
+            keyAlias = properties.getProperty("RELEASE_KEY_ALIAS")
+            keyPassword = properties.getProperty("RELEASE_KEY_PASSWORD")
+        }
     }
 
     buildTypes {
@@ -43,8 +54,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            signingConfig = signingConfigs.getByName("release")
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,13 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https"
+                    android:host="${deepLinkHostName}" />
+            </intent-filter>
         </activity>
 
         <service

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/fcm/FcmService.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/fcm/FcmService.kt
@@ -12,11 +12,11 @@ import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.net.toUri
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.domain.repository.UserRepository
-import com.ssafy.neegongnaegong.presentation.MainActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -42,33 +42,37 @@ class FcmService : FirebaseMessagingService() {
 
         createNotificationChannel()
 
-        val title = remoteMessage.notification?.title ?: "알림 제목 없음"
-        val body = remoteMessage.notification?.body ?: "알림 내용 없음"
+        val title = remoteMessage.data["title"] ?: remoteMessage.notification?.title ?: "알림 제목 없음"
+        val body = remoteMessage.data["body"] ?: remoteMessage.notification?.body ?: "알림 내용 없음"
         val id = remoteMessage.hashCode()
 
-        val intent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        }
+        val intent =
+            Intent(Intent.ACTION_VIEW, remoteMessage.data["deepLink"]?.toUri()).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
 
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
+        val pendingIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
 
-        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setSmallIcon(R.drawable.img_main_character)
-            .setContentTitle(title)
-            .setContentText(body)
-            .setContentIntent(pendingIntent)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .build()
+        val notification =
+            NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.drawable.img_main_character)
+                .setContentTitle(title)
+                .setContentText(body)
+                .setContentIntent(pendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(true)
+                .build()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (ActivityCompat.checkSelfPermission(
                     this,
-                    Manifest.permission.POST_NOTIFICATIONS
+                    Manifest.permission.POST_NOTIFICATIONS,
                 ) != PackageManager.PERMISSION_GRANTED
             ) {
                 Log.w("FcmService", "알림 권한이 없어 알림을 표시하지 않음.")
@@ -80,11 +84,12 @@ class FcmService : FirebaseMessagingService() {
     }
 
     private fun createNotificationChannel() {
-        val channel = NotificationChannel(
-            CHANNEL_ID,
-            CHANNEL_NAME,
-            NotificationManager.IMPORTANCE_HIGH
-        )
+        val channel =
+            NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH,
+            )
         val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         manager.createNotificationChannel(channel)
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/studygroup/StudyGroupDetailMapper.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/studygroup/StudyGroupDetailMapper.kt
@@ -2,7 +2,6 @@ package com.ssafy.neegongnaegong.data.mapper.studygroup
 
 import com.ssafy.neegongnaegong.data.model.studygroup.response.StudyGroupDetailResponse
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupDetailInfo
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
 
 internal object StudyGroupDetailMapper {
     fun StudyGroupDetailResponse.toDomain() =
@@ -20,7 +19,7 @@ internal object StudyGroupDetailMapper {
             leaderName = leaderName,
             createdDate = createdDate,
             tags = tags.toDomain(),
-            myGroupRole = runCatching<Role> { Role.valueOf(myGroupRole) }.getOrDefault(Role.PENDING),
+            myGroupRole = myGroupRole,
         )
 
     fun StudyGroupDetailResponse.Category.toDomain() = StudyGroupDetailInfo.Category(id = id, name = name)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/studygroup/response/StudyGroupDetailResponse.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/studygroup/response/StudyGroupDetailResponse.kt
@@ -1,6 +1,7 @@
 package com.ssafy.neegongnaegong.data.model.studygroup.response
 
 import com.google.gson.annotations.SerializedName
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import java.time.LocalDate
 
 data class StudyGroupDetailResponse(
@@ -18,7 +19,7 @@ data class StudyGroupDetailResponse(
     val createdDate: LocalDate,
     val tags: List<Tag>,
     @SerializedName("myGrouprole")
-    val myGroupRole: String,
+    val myGroupRole: Role,
 ) {
     data class Category(val id: Long, val name: String)
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/Role.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/Role.kt
@@ -1,8 +1,8 @@
-package com.ssafy.neegongnaegong.presentation.group.component.drawer.model
+package com.ssafy.neegongnaegong.domain.model.studygroup
 
-enum class Role(val role: String) {
-    LEADER("TEAM_LEADER"),
-    MANAGER("TEAM_MANAGER"),
-    MEMBER("TEAM_MEMBER"),
-    PENDING("PENDING"),
+enum class Role {
+    TEAM_LEADER,
+    TEAM_MANAGER,
+    TEAM_MEMBER,
+    PENDING,
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/StudyGroupDetailInfo.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/StudyGroupDetailInfo.kt
@@ -1,7 +1,5 @@
 package com.ssafy.neegongnaegong.domain.model.studygroup
 
-import com.ssafy.neegongnaegong.data.model.studygroup.response.StudyGroupDetailResponse.Category
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
 import java.time.LocalDate
 
 data class StudyGroupDetailInfo(

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/MainActivity.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/MainActivity.kt
@@ -7,8 +7,13 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.rememberNavController
 import com.ssafy.neegongnaegong.presentation.base.LoginStatusViewModel
+import com.ssafy.neegongnaegong.presentation.navigation.AppNavigation
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
 import com.ssafy.neegongnaegong.presentation.util.PermissionManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -48,9 +53,39 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         setContent {
+            val navController = rememberNavController()
+
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            /*
+            UI 없이 isLoading이 true로 즉 로딩되는 동안 계속해서 여기에 위치해 있다가
+            isLoading이 끝나는 순간 isLoginSuccess의 값에 따라 Login or Studies로 이동하도록
+             */
+            LaunchedEffect(state) {
+                println("싸피 $state $intent")
+                if (!state.isLoading) {
+                    // 알림을 눌러서 딥링크를 통해 들어온게 아닐 때
+                    if (intent.data == null) {
+                        navController.navigate(
+                            if (state.isLoginSuccess) AppNavigation.Tab.Studies else AppNavigation.Tab.Auth,
+                        ) {
+                            popUpTo("splash") { inclusive = true }
+                        }
+                    } else {
+                        if (state.isLoginSuccess) {
+                            navController.handleDeepLink(intent)
+                        } else {
+                            navController.navigate(AppNavigation.Tab.Auth) {
+                                popUpTo("splash") { inclusive = false }
+                            }
+                        }
+                    }
+                }
+            }
+
             NeeGongNaeGongTheme {
                 Surface(color = NeeGongNaeGongTheme.colorScheme.background) {
-                    MainScreen()
+                    MainScreen(navController)
                 }
             }
         }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/MainScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/MainScreen.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
@@ -48,9 +49,7 @@ import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
 import kotlinx.coroutines.launch
 
 @Composable
-fun MainScreen() {
-    val navController = rememberNavController()
-
+fun MainScreen(navController: NavHostController) {
     val resultLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             val needRefresh = result.data?.getBooleanExtra("needRefreshRecordList", false) ?: false
@@ -232,6 +231,6 @@ fun CalendarScreen() {
 @Composable
 fun PreviewMainScreen() {
     NeeGongNaeGongTheme {
-        MainScreen()
+        MainScreen(rememberNavController())
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/StudiesDrawer.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/StudiesDrawer.kt
@@ -48,10 +48,10 @@ import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.glide.GlideImage
 import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.domain.model.studygroup.MyStudyGroupInfo
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.presentation.group.component.drawer.component.ErrorItem
 import com.ssafy.neegongnaegong.presentation.group.component.drawer.component.LoadingItem
 import com.ssafy.neegongnaegong.presentation.group.component.drawer.component.NoDataItem
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
 import com.ssafy.neegongnaegong.presentation.group.detail.StudiesDetailContract
 import com.ssafy.neegongnaegong.presentation.group.detail.StudiesDetailViewModel
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
@@ -183,7 +183,7 @@ private fun StudiesDrawer(
             )
         }
 
-        if (role == Role.LEADER) {
+        if (role == Role.TEAM_LEADER) {
             item {
                 // 스터디 삭제 버튼
                 DrawerMenuItem(
@@ -374,7 +374,7 @@ private fun Preview_Leader_StudiesDrawer() {
             modifier = Modifier.fillMaxWidth(0.75F),
             name = "화이트 스터디",
             description = "하얗습니다.",
-            role = Role.LEADER,
+            role = Role.TEAM_LEADER,
             myStudyList = lazyItems,
         )
     }
@@ -423,7 +423,7 @@ private fun Preview_Manager_StudiesDrawer() {
             modifier = Modifier.fillMaxWidth(0.75F),
             name = "화이트 스터디",
             description = "하얗습니다.",
-            role = Role.MANAGER,
+            role = Role.TEAM_MANAGER,
             myStudyList = lazyItems,
         )
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailContract.kt
@@ -3,12 +3,12 @@ package com.ssafy.neegongnaegong.presentation.group.detail
 import com.ssafy.neegongnaegong.domain.model.learning.LearningRecord
 import com.ssafy.neegongnaegong.domain.model.studies.StudiesLatestContent
 import com.ssafy.neegongnaegong.domain.model.studies.WeeklyRankingsMember
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupDetailInfo
 import com.ssafy.neegongnaegong.presentation.base.ErrorContext
 import com.ssafy.neegongnaegong.presentation.base.UiEffect
 import com.ssafy.neegongnaegong.presentation.base.UiEvent
 import com.ssafy.neegongnaegong.presentation.base.UiState
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
 import java.time.LocalDate
 import java.time.LocalDateTime
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/edit/StudiesEditScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/edit/StudiesEditScreen.kt
@@ -62,13 +62,13 @@ import com.skydoves.landscapist.glide.GlideImage
 import com.ssafy.neegongnaegong.R
 import com.ssafy.neegongnaegong.domain.model.studies.Category
 import com.ssafy.neegongnaegong.domain.model.studies.Tag
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.presentation.component.LoadingDialog
 import com.ssafy.neegongnaegong.presentation.component.TopAppBar
 import com.ssafy.neegongnaegong.presentation.group.component.StudiesCategoryDropdown
 import com.ssafy.neegongnaegong.presentation.group.component.StudiesImagePicker
 import com.ssafy.neegongnaegong.presentation.group.component.StudiesMaxMemberDropdown
 import com.ssafy.neegongnaegong.presentation.group.component.StudiesTimeDropdown
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
 import com.ssafy.neegongnaegong.presentation.util.FileUtils.getFileExtension
@@ -184,7 +184,7 @@ private fun StudiesEditContent(
     }
     StudiesEditScreen(
         modifier = modifier,
-        enable = role == Role.LEADER,
+        enable = role == Role.TEAM_LEADER,
         name = uiState.studyInfo.name,
         isPublic = uiState.studyInfo.isPublic,
         targetStudyTime = uiState.studyInfo.targetStudyTime,
@@ -196,7 +196,7 @@ private fun StudiesEditContent(
         tags = uiState.tags,
         description = uiState.studyInfo.description,
         profileImg = uiState.studyInfo.profileImg,
-        validateCreateStudies = role == Role.LEADER && uiState.validateCreateStudies,
+        validateCreateStudies = role == Role.TEAM_LEADER && uiState.validateCreateStudies,
         onNameChanged = onNameChanged,
         onIsPublicChanged = onIsPublicChanged,
         onTargetStudyTimeChanged = onTargetStudyTimeChanged,

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/join/StudiesWaitingToJoinScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/join/StudiesWaitingToJoinScreen.kt
@@ -19,8 +19,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ssafy.neegongnaegong.domain.model.preview.studies.StudiesPreviewDataProvider
 import com.ssafy.neegongnaegong.domain.model.studies.StudiesApplicationsMember
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.presentation.component.TopAppBar
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
 import com.ssafy.neegongnaegong.presentation.group.join.component.StudiesApplicationJoinUnit
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
@@ -161,7 +161,7 @@ private fun Preview_Manager_StudiesWaitingToJoinScreen() {
         StudiesWaitingToJoinScreen(
             applicationsList = StudiesPreviewDataProvider().getStudiesApplications(),
             isLoading = false,
-            role = Role.MANAGER,
+            role = Role.TEAM_MANAGER,
             onLoadApplicationsList = {},
             onApproval = {},
             onReject = {},
@@ -177,7 +177,7 @@ private fun Preview_Member_StudiesWaitingToJoinScreen() {
         StudiesWaitingToJoinScreen(
             applicationsList = StudiesPreviewDataProvider().getStudiesApplications(),
             isLoading = false,
-            role = Role.MEMBER,
+            role = Role.TEAM_MEMBER,
             onLoadApplicationsList = {},
             onApproval = {},
             onReject = {},

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/join/component/StudiesApplicationJoinUnit.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/join/component/StudiesApplicationJoinUnit.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.skydoves.landscapist.glide.GlideImage
 import com.ssafy.neegongnaegong.R
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
 
@@ -41,7 +41,7 @@ fun StudiesApplicationJoinUnit(
     onReject: (Long) -> Unit = {},
 ) {
     val (backgroundColor, visibleButton) =
-        if (role in listOf(Role.MEMBER, Role.PENDING)) {
+        if (role in listOf(Role.TEAM_MANAGER, Role.PENDING)) {
             Pair(NeeGongNaeGongTheme.colorScheme.background, false)
         } else {
             when (status) {
@@ -164,7 +164,7 @@ private fun PreviewPendingStudiesApplicationJoinUnit() {
     NeeGongNaeGongTheme {
         StudiesApplicationJoinUnit(
             name = "심터디",
-            role = Role.MANAGER,
+            role = Role.TEAM_MANAGER,
             status = StudiesJoinApplicationStatus.PENDING,
             userId = 1,
             profileImageUrl = "https://picsum.photos/200",
@@ -180,7 +180,7 @@ private fun PreviewApprovedStudiesApplicationJoinUnit() {
     NeeGongNaeGongTheme {
         StudiesApplicationJoinUnit(
             name = "심터디",
-            role = Role.MEMBER,
+            role = Role.TEAM_MEMBER,
             status = StudiesJoinApplicationStatus.APPROVED,
             userId = 1,
             profileImageUrl = "https://picsum.photos/200",
@@ -196,7 +196,7 @@ private fun PreviewRejectedStudiesApplicationJoinUnit() {
     NeeGongNaeGongTheme {
         StudiesApplicationJoinUnit(
             name = "심터디",
-            role = Role.MEMBER,
+            role = Role.TEAM_MEMBER,
             status = StudiesJoinApplicationStatus.REJECTED,
             userId = 1,
             profileImageUrl = "https://picsum.photos/200",

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/main/ListViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/main/ListViewModel.kt
@@ -2,6 +2,7 @@ package com.ssafy.neegongnaegong.presentation.group.list.main
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.ssafy.neegongnaegong.domain.model.studygroup.NoticeHistoryInfo
@@ -11,9 +12,9 @@ import com.ssafy.neegongnaegong.domain.usecase.studygroup.GetVoteListUseCase
 import com.ssafy.neegongnaegong.presentation.base.BaseViewModel
 import com.ssafy.neegongnaegong.presentation.group.list.main.ListContract.Effect
 import com.ssafy.neegongnaegong.presentation.group.list.main.ListContract.Index
+import com.ssafy.neegongnaegong.presentation.navigation.AppNavigation
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 @HiltViewModel
@@ -61,25 +62,18 @@ class ListViewModel
         val voteListFlow: Flow<PagingData<VoteHistoryInfo>>
 
         init {
-            val groupId: Long? = savedStateHandle["groupId"]
-            val startTabIdx: Int? = savedStateHandle["startTab"]
-            if (groupId != null && startTabIdx != null) {
-                setState { copy(groupId = groupId) }
+            val studyGroupId = savedStateHandle.toRoute<AppNavigation.Screen.Studies.SubTab.Main>().studyGroupId
 
-                noticeListFlow =
-                    getNoticeListUseCase(groupId).cachedIn(
-                        viewModelScope,
-                    )
+            setState { copy(groupId = studyGroupId) }
 
-                voteListFlow =
-                    getVoteListUseCase(groupId).cachedIn(
-                        viewModelScope,
-                    )
-            } else {
-                noticeListFlow = flow {}
-                voteListFlow = flow {}
-                showErrorMessage("잘못된 접근입니다")
-                setEvent(ListContract.Event.InvalidAccess)
-            }
+            noticeListFlow =
+                getNoticeListUseCase(studyGroupId).cachedIn(
+                    viewModelScope,
+                )
+
+            voteListFlow =
+                getVoteListUseCase(studyGroupId).cachedIn(
+                    viewModelScope,
+                )
         }
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/notice/NoticeDetailViewModel.kt
@@ -68,7 +68,7 @@ class NoticeDetailViewModel
         }
 
         private val groupId: Long =
-            savedStateHandle.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>().groupId
+            savedStateHandle.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>().studyGroupId
         private val noticeId: Long =
             savedStateHandle.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>().noticeId
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/VoteDetailViewModel.kt
@@ -172,7 +172,7 @@ class VoteDetailViewModel
         }
 
         private val groupId: Long =
-            savedStateHandle.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail>().groupId
+            savedStateHandle.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail>().studyGroupId
         private val voteId: Long =
             savedStateHandle.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail>().voteId
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordScreen.kt
@@ -63,13 +63,13 @@ private const val TAG = "RecordScreen"
 
 @Composable
 fun RecordRoute(
-    groupId: Long,
+    studyGroupId: Long,
     memberId: Long,
     popBackStack: () -> Boolean,
     modifier: Modifier = Modifier,
     viewModel: RecordViewModel = hiltViewModel(),
 ) {
-    Log.d(TAG, "RecordRoute: $groupId $memberId") // TODO : dekekt 통과 임시 적용
+    Log.d(TAG, "RecordRoute: $studyGroupId $memberId") // TODO : dekekt 통과 임시 적용
     val pagingItem = viewModel.studyLogFlow.collectAsLazyPagingItems()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordViewModel.kt
@@ -2,6 +2,7 @@ package com.ssafy.neegongnaegong.presentation.group.record
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyContentInfo
@@ -9,11 +10,11 @@ import com.ssafy.neegongnaegong.domain.model.studygroup.StudyMemberInfo
 import com.ssafy.neegongnaegong.domain.usecase.studygroup.GetMemberStudyContentsUseCase
 import com.ssafy.neegongnaegong.domain.usecase.studygroup.GetMemberStudyLogsByTagUseCase
 import com.ssafy.neegongnaegong.presentation.base.BaseViewModel
+import com.ssafy.neegongnaegong.presentation.navigation.AppNavigation
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -36,26 +37,23 @@ class RecordViewModel
             }
         }
 
-        private val groupId: Long? = savedStateHandle["groupId"]
-        private val userId: Long? = savedStateHandle["memberId"]
         val studyLogFlow: Flow<PagingData<StudyContentInfo>>
 
         init {
-            if (groupId != null && userId != null) {
-                studyLogFlow =
-                    getMemberStudyContentsUseCase(StudyMemberInfo(groupId, userId)).cachedIn(
-                        viewModelScope,
-                    )
-                viewModelScope.launch {
-                    getMemberStudyLogsByTagUseCase(StudyMemberInfo(groupId, userId)).safeCollect {
-                        setState { copy(studyLogsByTag = it.toPersistentList()) }
-                    }
+            val (studyGroupId, userId) =
+                with(savedStateHandle.toRoute<AppNavigation.Screen.Studies.Record>()) {
+                    Pair(this.studyGroupId, memberId)
                 }
-            } else {
-                // studyLogFlow를 nullable하게 처리하고 싶지 않다보니 에러로 쓰지 않을 것임에도 초기화를 진행하게 되네요
-                studyLogFlow = flow {}
-                showErrorMessage("잘못된 경로입니다")
-                setEvent(RecordContract.Event.InvalidAccess)
+
+            studyLogFlow =
+                getMemberStudyContentsUseCase(StudyMemberInfo(studyGroupId, userId)).cachedIn(
+                    viewModelScope,
+                )
+
+            viewModelScope.launch {
+                getMemberStudyLogsByTagUseCase(StudyMemberInfo(studyGroupId, userId)).safeCollect {
+                    setState { copy(studyLogsByTag = it.toPersistentList()) }
+                }
             }
         }
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/role/StudiesMemberRoleScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/role/StudiesMemberRoleScreen.kt
@@ -19,8 +19,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ssafy.neegongnaegong.domain.model.preview.studies.StudiesPreviewDataProvider
 import com.ssafy.neegongnaegong.domain.model.studies.StudiesMember
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.presentation.component.TopAppBar
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
 import com.ssafy.neegongnaegong.presentation.group.role.component.ExpelMemberDialog
 import com.ssafy.neegongnaegong.presentation.group.role.component.RoleChangeDialog
 import com.ssafy.neegongnaegong.presentation.group.role.component.StudiesMemberRole
@@ -208,7 +208,7 @@ private fun Preview_Leader_StudiesMemberRoleScreen() {
     NeeGongNaeGongTheme {
         StudiesMemberRoleScreen(
             isLoading = false,
-            role = Role.LEADER,
+            role = Role.TEAM_LEADER,
             studiesMembers = StudiesPreviewDataProvider().getStudiesMembers(),
             onSelectedMember = {},
             onChangeRoleDialogShow = {},
@@ -224,7 +224,7 @@ private fun Preview_Member_StudiesMemberRoleScreen() {
     NeeGongNaeGongTheme {
         StudiesMemberRoleScreen(
             isLoading = false,
-            role = Role.MEMBER,
+            role = Role.TEAM_MEMBER,
             studiesMembers = StudiesPreviewDataProvider().getStudiesMembers(),
             onSelectedMember = {},
             onChangeRoleDialogShow = {},

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/role/component/StudiesMemberRoleUnit.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/role/component/StudiesMemberRoleUnit.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.skydoves.landscapist.glide.GlideImage
 import com.ssafy.neegongnaegong.R
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
 
@@ -37,7 +37,7 @@ fun StudiesMemberRoleUnit(
     onChangeRole: () -> Unit = {},
     onExpel: () -> Unit = {},
 ) {
-    val enable = myRole == Role.LEADER
+    val enable = myRole == Role.TEAM_LEADER
     Row(
         modifier =
             modifier
@@ -143,7 +143,7 @@ fun StudiesMemberRoleUnit(
 private fun Preview_Leader_StudiesMemberRoleUnit() {
     NeeGongNaeGongTheme {
         StudiesMemberRoleUnit(
-            myRole = Role.LEADER,
+            myRole = Role.TEAM_LEADER,
             memberRole = StudiesMemberRole.TEAM_MEMBER,
             name = "심터디",
             profileImageUrl = "https://example.com/profile.jpg",
@@ -156,7 +156,7 @@ private fun Preview_Leader_StudiesMemberRoleUnit() {
 private fun Preview_Member_StudiesMemberRoleUnit() {
     NeeGongNaeGongTheme {
         StudiesMemberRoleUnit(
-            myRole = Role.MEMBER,
+            myRole = Role.TEAM_MEMBER,
             memberRole = StudiesMemberRole.TEAM_MEMBER,
             name = "심터디",
             profileImageUrl = "https://example.com/profile.jpg",

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
@@ -30,6 +30,12 @@ object AppNavigation {
         data object Studies : Tab
 
         @Serializable
+        data object StudiesDetail : Tab
+
+        @Serializable
+        data object StudiesSubTabDetail : Tab
+
+        @Serializable
         data object Personal : Tab
 
         @Serializable
@@ -84,7 +90,7 @@ object AppNavigation {
             data class MakeNotice(val studyGroupId: Long) : Studies
 
             @Serializable
-            data class Record(val groupId: Long, val memberId: Long) : Studies
+            data class Record(val studyGroupId: Long, val memberId: Long) : Studies
 
             @Serializable
             sealed interface SubTab : Studies {
@@ -94,15 +100,15 @@ object AppNavigation {
                 }
 
                 @Serializable
-                data class Main(val startTab: Int, val groupId: Long) : SubTab
+                data class Main(val startTab: Int = 0, val studyGroupId: Long) : SubTab
 
                 @Serializable
                 sealed interface Screen : SubTab {
                     @Serializable
-                    data class NoticeDetail(val groupId: Long, val noticeId: Long) : Screen
+                    data class NoticeDetail(val studyGroupId: Long, val noticeId: Long) : Screen
 
                     @Serializable
-                    data class VoteDetail(val groupId: Long, val voteId: Long) : Screen
+                    data class VoteDetail(val studyGroupId: Long, val voteId: Long) : Screen
 
                     // 객체의 리스트를 내비게이션의 인자로 보낼 수가 없어서 json으로 List<StudyGroupVoteStatusInfo.VotedMemberInfo>을 String으로 변환한 값을 전달 후 복호화
                     @Serializable

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/AppNavigation.kt
@@ -1,7 +1,7 @@
 package com.ssafy.neegongnaegong.presentation.navigation
 
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.presentation.calendar.component.form.ScheduleInputFormFocus
-import com.ssafy.neegongnaegong.presentation.group.component.drawer.model.Role
 import kotlinx.serialization.Serializable
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/MainNavigationGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/MainNavigationGraph.kt
@@ -1,36 +1,13 @@
 package com.ssafy.neegongnaegong.presentation.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.ssafy.neegongnaegong.presentation.base.LoginStatusViewModel
 
 @Composable
-fun MainNavigationGraph(
-    navController: NavHostController,
-    viewModel: LoginStatusViewModel = hiltViewModel()
-) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
-
-    /*
-    UI 없이 isLoading이 true로 즉 로딩되는 동안 계속해서 여기에 위치해 있다가
-    isLoading이 끝나는 순간 isLoginSuccess의 값에 따라 Login or Studies로 이동하도록
-     */
-    LaunchedEffect(state) {
-        if (!state.isLoading) {
-            navController.navigate(
-                if (state.isLoginSuccess) AppNavigation.Tab.Studies else AppNavigation.Tab.Auth
-            ) {
-                popUpTo("splash") { inclusive = true }
-            }
-        }
-    }
-
+fun MainNavigationGraph(navController: NavHostController) {
     NavHost(
         navController = navController,
         startDestination = "splash",

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/ProfileNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/ProfileNavGraph.kt
@@ -37,7 +37,7 @@ fun NavGraphBuilder.profileNavGraph(navController: NavController) {
                     val detail = AppNavigation.Screen.Studies.StudiesDetail(studyGroupId = groupId)
                     val notice =
                         AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail(
-                            groupId = groupId,
+                            studyGroupId = groupId,
                             noticeId = noticeId,
                         )
                     navController.navigate(route = detail)
@@ -47,7 +47,7 @@ fun NavGraphBuilder.profileNavGraph(navController: NavController) {
                     val detail = AppNavigation.Screen.Studies.StudiesDetail(studyGroupId = groupId)
                     val vote =
                         AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail(
-                            groupId = groupId,
+                            studyGroupId = groupId,
                             voteId = voteId,
                         )
                     navController.navigate(route = detail)

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
@@ -94,7 +94,15 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
             )
         }
 
-        composable<AppNavigation.Screen.Studies.StudiesApplication> { backStackEntry ->
+        composable<AppNavigation.Screen.Studies.StudiesApplication>(
+            deepLinks =
+                listOf(
+                    navDeepLink {
+                        uriPattern = "$BASE_DEEP_LINK/study-group/{studyGroupId}/manage/{role}"
+                        action = Intent.ACTION_VIEW
+                    },
+                ),
+        ) { backStackEntry ->
             val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.StudiesApplication>()
             StudiesWaitingToJoinRoute(
                 modifier = Modifier,

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
@@ -52,270 +52,279 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
             )
         }
 
-        composable<AppNavigation.Screen.Studies.StudiesDetail>(
-            deepLinks =
-                listOf(
-                    navDeepLink {
-                        uriPattern = "$BASE_DEEP_LINK/study-group/{studyGroupId}"
-                        action = Intent.ACTION_VIEW
-                    },
-                ),
-        ) { backStackEntry ->
-            val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.StudiesDetail>()
-            StudiesDetailRoute(
-                modifier = Modifier,
-                navBackStackEntry = backStackEntry,
-                studyGroupId = route.studyGroupId,
-                navigateToContents = { startTabIndex, studyGroupId ->
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.SubTab.Main(
-                            startTabIndex,
-                            studyGroupId,
-                        ),
-                    )
-                },
-                navigateToLatestNoticeDetail = { studyGroupId, noticeId ->
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail(
-                            studyGroupId,
-                            noticeId,
-                        ),
-                    )
-                },
-                navigateToLatestVoteDetail = { studyGroupId, voteId ->
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail(
-                            studyGroupId,
-                            voteId,
-                        ),
-                    )
-                },
-                popBackStack = navController::popBackStack,
-            )
-        }
-
-        composable<AppNavigation.Screen.Studies.StudiesApplication>(
-            deepLinks =
-                listOf(
-                    navDeepLink {
-                        uriPattern = "$BASE_DEEP_LINK/study-group/{studyGroupId}/manage/{role}"
-                        action = Intent.ACTION_VIEW
-                    },
-                ),
-        ) { backStackEntry ->
-            val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.StudiesApplication>()
-            StudiesWaitingToJoinRoute(
-                modifier = Modifier,
-                studyGroupId = route.studyGroupId,
-                role = route.role,
-                popBackStack = navController::popBackStack,
-            )
-        }
-
-        composable<AppNavigation.Screen.Studies.StudiesMembersRole> { backStackEntry ->
-            val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.StudiesMembersRole>()
-            StudiesMemberRoleRoute(
-                modifier = Modifier,
-                studyGroupId = route.studyGroupId,
-                role = route.role,
-                popBackStack = navController::popBackStack,
-            )
-        }
-        composable<AppNavigation.Screen.Studies.Create> {
-            StudiesCreateRoute(
-                modifier = Modifier,
-                popBackStack = navController::popBackStack,
-            )
-        }
-
-        composable<AppNavigation.Screen.Studies.Edit> { backStackEntry ->
-            val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.Edit>()
-            StudiesEditRoute(
-                modifier = Modifier,
-                studyGroupId = route.studyGroupId,
-                role = route.role,
-                popBackStack = navController::popBackStack,
-            )
-        }
-
-        composable<AppNavigation.Screen.Studies.MakeVote> {
-            VoteRoute(
-                navigateToMain = { startTab, groupId ->
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.SubTab.Main(
-                            startTab,
-                            groupId,
-                        ),
-                    ) {
-                        popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
-                            inclusive = true
-                        }
-                    }
-                },
-                popBackStack = navController::popBackStack,
-            )
-        }
-
-        composable<AppNavigation.Screen.Studies.MakeNotice> {
-            NoticeRoute(
-                popBackStackInclusive = { startTab, groupId ->
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.SubTab.Main(
-                            startTab,
-                            groupId,
-                        ),
-                    ) {
-                        popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
-                            inclusive = true
-                        }
-                    }
-                },
-                popBackStack = navController::popBackStack,
-            )
-        }
-
-        composable<AppNavigation.Screen.Studies.Record> { backStackEntry ->
-            val (groupId, memberId) = backStackEntry.toRoute<AppNavigation.Screen.Studies.Record>()
-            RecordRoute(
-                groupId = groupId,
-                memberId = memberId,
-                popBackStack = navController::popBackStack,
-            )
-        }
-
-        composable<AppNavigation.Screen.Studies.SubTab.Main> { backStackEntry ->
-            val (startTabIndex, groupId) = backStackEntry.toRoute<AppNavigation.Screen.Studies.SubTab.Main>()
-            ListRoute(
-                popBackStack = navController::popBackStack,
-                startTabIdx = startTabIndex,
-                navigateToNoticeDetail = {
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.SubTab.Screen
-                            .NoticeDetail(groupId, it),
-                    ) {
-                        popUpTo<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail> {
-                            inclusive = false
-                        }
-                    }
-                },
-                navigateToVoteDetail = {
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.SubTab.Screen
-                            .VoteDetail(groupId, it),
-                    ) {
-                        popUpTo<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail> {
-                            inclusive = false
-                        }
-                    }
-                },
-                navigateToMakeNotice = {
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.MakeNotice(groupId),
-                    ) {
-                        popUpTo<AppNavigation.Screen.Studies.MakeNotice> {
-                            inclusive = false
-                        }
-                    }
-                },
-                navigateToMakeVote = {
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.MakeVote(groupId),
-                    ) {
-                        popUpTo<AppNavigation.Screen.Studies.MakeVote> {
-                            inclusive = false
-                        }
-                    }
-                },
-            )
-        }
-
-        composable<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>(
-            deepLinks =
-                listOf(
-                    navDeepLink {
-                        uriPattern = "$BASE_DEEP_LINK/study-group/{groupId}/notice/{noticeId}"
-                        action = Intent.ACTION_VIEW
-                    },
-                ),
+        navigation<AppNavigation.Tab.StudiesDetail>(
+            startDestination = AppNavigation.Screen.Studies.StudiesDetail(-1),
         ) {
-            val groupId =
-                it.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>().groupId
-            NoticeDetailRoute(
-                backStackEntry = it,
-                viewModel = hiltViewModel(it),
-                popBackStack = navController::popBackStack,
-            ) {
-                navController.navigate(
-                    AppNavigation.Screen.Studies.SubTab.Main(
-                        startTab = AppNavigation.Screen.Studies.SubTab.SubTabMenu.NoticeTab.index,
-                        groupId = groupId,
+            composable<AppNavigation.Screen.Studies.StudiesDetail>(
+                deepLinks =
+                    listOf(
+                        navDeepLink {
+                            uriPattern = "$BASE_DEEP_LINK/study-group/{studyGroupId}"
+                            action = Intent.ACTION_VIEW
+                        },
                     ),
-                ) {
-                    popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
-                        inclusive = true
-                    }
-                }
-            }
-        }
-
-        composable<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail> (
-            deepLinks =
-                listOf(
-                    navDeepLink {
-                        uriPattern = "$BASE_DEEP_LINK/study-group/{groupId}/vote/{voteId}"
-                        action = Intent.ACTION_VIEW
-                    },
-                ),
-        ) {
-            val groupId =
-                it.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail>().groupId
-            VoteDetailRoute(
-                backStackEntry = it,
-                viewModel = hiltViewModel(it),
-                navigateToVotedPersonList = { title, votedPersonList ->
-                    val json = Json.encodeToString(votedPersonList)
-                    navController.navigate(
-                        AppNavigation.Screen.Studies.SubTab.Screen
-                            .VotedPerson(title, json),
-                    )
-                },
-                popBackStack = navController::popBackStack,
-            ) {
-                navController.navigate(
-                    AppNavigation.Screen.Studies.SubTab.Main(
-                        startTab = AppNavigation.Screen.Studies.SubTab.SubTabMenu.VoteTab.index,
-                        groupId = groupId,
-                    ),
-                ) {
-                    popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
-                        inclusive = true
-                    }
-                }
-            }
-        }
-
-        composable<AppNavigation.Screen.Studies.SubTab.Screen.VotedPerson> { backStackEntry ->
-            val (title, votedPersonList) =
-                backStackEntry
-                    .toRoute<AppNavigation.Screen.Studies.SubTab.Screen.VotedPerson>()
-                    .let {
-                        Pair(
-                            it.title,
-                            it.votedPersonList.let { jsonPersonList ->
-                                Json.decodeFromString<List<StudyGroupVoteStatusInfo.VotedMemberInfo>>(
-                                    jsonPersonList,
-                                )
-                            },
+            ) { backStackEntry ->
+                val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.StudiesDetail>()
+                StudiesDetailRoute(
+                    modifier = Modifier,
+                    navBackStackEntry = backStackEntry,
+                    studyGroupId = route.studyGroupId,
+                    navigateToContents = { startTabIndex, studyGroupId ->
+                        navController.navigate(
+                            AppNavigation.Screen.Studies.SubTab.Main(
+                                startTabIndex,
+                                studyGroupId,
+                            ),
                         )
-                    }
-            VotedPersonListRoute(
-                title,
-                votedPersonList,
+                    },
+                    navigateToLatestNoticeDetail = { studyGroupId, noticeId ->
+                        navController.navigate(
+                            AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail(
+                                studyGroupId,
+                                noticeId,
+                            ),
+                        )
+                    },
+                    navigateToLatestVoteDetail = { studyGroupId, voteId ->
+                        navController.navigate(
+                            AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail(
+                                studyGroupId,
+                                voteId,
+                            ),
+                        )
+                    },
+                    popBackStack = navController::popBackStack,
+                )
+            }
+
+            composable<AppNavigation.Screen.Studies.StudiesApplication>(
+                deepLinks =
+                    listOf(
+                        navDeepLink {
+                            uriPattern = "$BASE_DEEP_LINK/study-group/{studyGroupId}/manage/{role}"
+                            action = Intent.ACTION_VIEW
+                        },
+                    ),
+            ) { backStackEntry ->
+                val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.StudiesApplication>()
+                StudiesWaitingToJoinRoute(
+                    modifier = Modifier,
+                    studyGroupId = route.studyGroupId,
+                    role = route.role,
+                    popBackStack = navController::popBackStack,
+                )
+            }
+
+            composable<AppNavigation.Screen.Studies.StudiesMembersRole> { backStackEntry ->
+                val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.StudiesMembersRole>()
+                StudiesMemberRoleRoute(
+                    modifier = Modifier,
+                    studyGroupId = route.studyGroupId,
+                    role = route.role,
+                    popBackStack = navController::popBackStack,
+                )
+            }
+
+            composable<AppNavigation.Screen.Studies.Create> {
+                StudiesCreateRoute(
+                    modifier = Modifier,
+                    popBackStack = navController::popBackStack,
+                )
+            }
+
+            composable<AppNavigation.Screen.Studies.Edit> { backStackEntry ->
+                val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.Edit>()
+                StudiesEditRoute(
+                    modifier = Modifier,
+                    studyGroupId = route.studyGroupId,
+                    role = route.role,
+                    popBackStack = navController::popBackStack,
+                )
+            }
+
+            composable<AppNavigation.Screen.Studies.MakeVote> {
+                VoteRoute(
+                    navigateToMain = { startTab, studyGroupId ->
+                        navController.navigate(
+                            AppNavigation.Screen.Studies.SubTab.Main(
+                                startTab,
+                                studyGroupId,
+                            ),
+                        ) {
+                            popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
+                                inclusive = true
+                            }
+                        }
+                    },
+                    popBackStack = navController::popBackStack,
+                )
+            }
+
+            composable<AppNavigation.Screen.Studies.MakeNotice> {
+                NoticeRoute(
+                    popBackStackInclusive = { startTab, studyGroupId ->
+                        navController.navigate(
+                            AppNavigation.Screen.Studies.SubTab.Main(
+                                startTab,
+                                studyGroupId,
+                            ),
+                        ) {
+                            popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
+                                inclusive = true
+                            }
+                        }
+                    },
+                    popBackStack = navController::popBackStack,
+                )
+            }
+
+            composable<AppNavigation.Screen.Studies.Record> { backStackEntry ->
+                val (studyGroupId, memberId) = backStackEntry.toRoute<AppNavigation.Screen.Studies.Record>()
+                RecordRoute(
+                    studyGroupId = studyGroupId,
+                    memberId = memberId,
+                    popBackStack = navController::popBackStack,
+                )
+            }
+
+            navigation<AppNavigation.Tab.StudiesSubTabDetail>(
+                startDestination = AppNavigation.Screen.Studies.SubTab.Main(0, -1),
             ) {
-                navController.popBackStack()
+                composable<AppNavigation.Screen.Studies.SubTab.Main> { backStackEntry ->
+                    val (startTabIndex, studyGroupId) = backStackEntry.toRoute<AppNavigation.Screen.Studies.SubTab.Main>()
+                    ListRoute(
+                        popBackStack = navController::popBackStack,
+                        startTabIdx = startTabIndex,
+                        navigateToNoticeDetail = {
+                            navController.navigate(
+                                AppNavigation.Screen.Studies.SubTab.Screen
+                                    .NoticeDetail(studyGroupId, it),
+                            ) {
+                                popUpTo<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail> {
+                                    inclusive = false
+                                }
+                            }
+                        },
+                        navigateToVoteDetail = {
+                            navController.navigate(
+                                AppNavigation.Screen.Studies.SubTab.Screen
+                                    .VoteDetail(studyGroupId, it),
+                            ) {
+                                popUpTo<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail> {
+                                    inclusive = false
+                                }
+                            }
+                        },
+                        navigateToMakeNotice = {
+                            navController.navigate(
+                                AppNavigation.Screen.Studies.MakeNotice(studyGroupId),
+                            ) {
+                                popUpTo<AppNavigation.Screen.Studies.MakeNotice> {
+                                    inclusive = false
+                                }
+                            }
+                        },
+                        navigateToMakeVote = {
+                            navController.navigate(
+                                AppNavigation.Screen.Studies.MakeVote(studyGroupId),
+                            ) {
+                                popUpTo<AppNavigation.Screen.Studies.MakeVote> {
+                                    inclusive = false
+                                }
+                            }
+                        },
+                    )
+                }
+
+                composable<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>(
+                    deepLinks =
+                        listOf(
+                            navDeepLink {
+                                uriPattern = "$BASE_DEEP_LINK/study-group/{studyGroupId}/notice/{noticeId}"
+                                action = Intent.ACTION_VIEW
+                            },
+                        ),
+                ) {
+                    val studyGroupId =
+                        it.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>().studyGroupId
+                    NoticeDetailRoute(
+                        backStackEntry = it,
+                        viewModel = hiltViewModel(it),
+                        popBackStack = navController::popBackStack,
+                    ) {
+                        navController.navigate(
+                            AppNavigation.Screen.Studies.SubTab.Main(
+                                startTab = AppNavigation.Screen.Studies.SubTab.SubTabMenu.NoticeTab.index,
+                                studyGroupId = studyGroupId,
+                            ),
+                        ) {
+                            popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
+                                inclusive = true
+                            }
+                        }
+                    }
+                }
+
+                composable<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail> (
+                    deepLinks =
+                        listOf(
+                            navDeepLink {
+                                uriPattern = "$BASE_DEEP_LINK/study-group/{studyGroupId}/vote/{voteId}"
+                                action = Intent.ACTION_VIEW
+                            },
+                        ),
+                ) {
+                    val studyGroupId =
+                        it.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail>().studyGroupId
+                    VoteDetailRoute(
+                        backStackEntry = it,
+                        viewModel = hiltViewModel(it),
+                        navigateToVotedPersonList = { title, votedPersonList ->
+                            val json = Json.encodeToString(votedPersonList)
+                            navController.navigate(
+                                AppNavigation.Screen.Studies.SubTab.Screen
+                                    .VotedPerson(title, json),
+                            )
+                        },
+                        popBackStack = navController::popBackStack,
+                    ) {
+                        navController.navigate(
+                            AppNavigation.Screen.Studies.SubTab.Main(
+                                startTab = AppNavigation.Screen.Studies.SubTab.SubTabMenu.VoteTab.index,
+                                studyGroupId = studyGroupId,
+                            ),
+                        ) {
+                            popUpTo<AppNavigation.Screen.Studies.SubTab.Main> {
+                                inclusive = true
+                            }
+                        }
+                    }
+                }
+
+                composable<AppNavigation.Screen.Studies.SubTab.Screen.VotedPerson> { backStackEntry ->
+                    val (title, votedPersonList) =
+                        backStackEntry
+                            .toRoute<AppNavigation.Screen.Studies.SubTab.Screen.VotedPerson>()
+                            .let {
+                                Pair(
+                                    it.title,
+                                    it.votedPersonList.let { jsonPersonList ->
+                                        Json.decodeFromString<List<StudyGroupVoteStatusInfo.VotedMemberInfo>>(
+                                            jsonPersonList,
+                                        )
+                                    },
+                                )
+                            }
+                    VotedPersonListRoute(
+                        title,
+                        votedPersonList,
+                    ) {
+                        navController.popBackStack()
+                    }
+                }
             }
         }
     }
 }
 
-val BASE_DEEP_LINK: String = BuildConfig.BASE_URL
+const val BASE_DEEP_LINK: String = BuildConfig.BASE_URL

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
@@ -1,13 +1,16 @@
 package com.ssafy.neegongnaegong.presentation.navigation
 
 import VotedPersonListRoute
+import android.content.Intent
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import androidx.navigation.navigation
 import androidx.navigation.toRoute
+import com.ssafy.neegongnaegong.BuildConfig
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupVoteStatusInfo
 import com.ssafy.neegongnaegong.presentation.group.StudiesRoute
 import com.ssafy.neegongnaegong.presentation.group.create.StudiesCreateRoute
@@ -49,7 +52,15 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
             )
         }
 
-        composable<AppNavigation.Screen.Studies.StudiesDetail> { backStackEntry ->
+        composable<AppNavigation.Screen.Studies.StudiesDetail>(
+            deepLinks =
+                listOf(
+                    navDeepLink {
+                        uriPattern = "$BASE_DEEP_LINK/study/{studyGroupId}"
+                        action = Intent.ACTION_VIEW
+                    },
+                ),
+        ) { backStackEntry ->
             val route = backStackEntry.toRoute<AppNavigation.Screen.Studies.StudiesDetail>()
             StudiesDetailRoute(
                 modifier = Modifier,
@@ -210,7 +221,15 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
             )
         }
 
-        composable<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail> {
+        composable<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>(
+            deepLinks =
+                listOf(
+                    navDeepLink {
+                        uriPattern = "$BASE_DEEP_LINK/study/{groupId}/notice/{noticeId}"
+                        action = Intent.ACTION_VIEW
+                    },
+                ),
+        ) {
             val groupId =
                 it.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.NoticeDetail>().groupId
             NoticeDetailRoute(
@@ -231,7 +250,15 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
             }
         }
 
-        composable<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail> {
+        composable<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail> (
+            deepLinks =
+                listOf(
+                    navDeepLink {
+                        uriPattern = "$BASE_DEEP_LINK/study/{groupId}/vote/{voteId}"
+                        action = Intent.ACTION_VIEW
+                    },
+                ),
+        ) {
             val groupId =
                 it.toRoute<AppNavigation.Screen.Studies.SubTab.Screen.VoteDetail>().groupId
             VoteDetailRoute(
@@ -282,3 +309,5 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
         }
     }
 }
+
+val BASE_DEEP_LINK: String = BuildConfig.BASE_URL

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
@@ -56,7 +56,7 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
             deepLinks =
                 listOf(
                     navDeepLink {
-                        uriPattern = "$BASE_DEEP_LINK/study/{studyGroupId}"
+                        uriPattern = "$BASE_DEEP_LINK/study-group/{studyGroupId}"
                         action = Intent.ACTION_VIEW
                     },
                 ),
@@ -225,7 +225,7 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
             deepLinks =
                 listOf(
                     navDeepLink {
-                        uriPattern = "$BASE_DEEP_LINK/study/{groupId}/notice/{noticeId}"
+                        uriPattern = "$BASE_DEEP_LINK/study-group/{groupId}/notice/{noticeId}"
                         action = Intent.ACTION_VIEW
                     },
                 ),
@@ -254,7 +254,7 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
             deepLinks =
                 listOf(
                     navDeepLink {
-                        uriPattern = "$BASE_DEEP_LINK/study/{groupId}/vote/{voteId}"
+                        uriPattern = "$BASE_DEEP_LINK/study-group/{groupId}/vote/{voteId}"
                         action = Intent.ACTION_VIEW
                     },
                 ),

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationScreen.kt
@@ -30,7 +30,7 @@ import com.ssafy.neegongnaegong.presentation.component.refresh.DefaultRefreshBox
 import com.ssafy.neegongnaegong.presentation.notification.component.NotificationList
 import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.random.Random
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -116,7 +116,7 @@ fun NotificationScreen(
 @Composable
 @Preview
 fun NotificationPreviewScreen() {
-    val testModel =
+    val testModel = {
         NotificationUiModel(
             id = Random.nextLong(),
             image =
@@ -132,19 +132,22 @@ fun NotificationPreviewScreen() {
             studyGroupId = null,
             studyGroupName = null,
         )
-    val testList = List<NotificationUiModel>(500) { testModel }
-    val fakeFlow = flowOf(PagingData.from(testList)).collectAsLazyPagingItems()
+    }
+    val testList = List<NotificationUiModel>(500) { testModel() }
+    val fakeFlow = MutableStateFlow(PagingData.from(testList)).collectAsLazyPagingItems()
 
-    NotificationScreen(
-        isRefresh = false,
-        listState = rememberLazyListState(),
-        notificationList = fakeFlow,
-        onNavigateUp = {},
-        onRefresh = {},
-        onDeleteAll = {},
-        onDeleteNotification = {},
-        onMoveNotification = {},
-        onAcceptGroupJoinRequest = {},
-        onRejectGroupJoinRequest = {},
-    )
+    NeeGongNaeGongTheme {
+        NotificationScreen(
+            isRefresh = false,
+            listState = rememberLazyListState(),
+            notificationList = fakeFlow,
+            onNavigateUp = {},
+            onRefresh = {},
+            onDeleteAll = {},
+            onDeleteNotification = {},
+            onMoveNotification = {},
+            onAcceptGroupJoinRequest = {},
+            onRejectGroupJoinRequest = {},
+        )
+    }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/component/NotificationList.kt
@@ -3,11 +3,18 @@ package com.ssafy.neegongnaegong.presentation.notification.component
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.ssafy.neegongnaegong.domain.model.notification.NotificationType
 import com.ssafy.neegongnaegong.presentation.notification.data.NotificationUiModel
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.random.Random
 
 @Composable
 fun NotificationList(
@@ -41,5 +48,40 @@ fun NotificationList(
                 onReject = { onRejectGroupJoinRequest(data) },
             )
         }
+    }
+}
+
+@Composable
+@NeeGongNaeGongPreviews
+fun PreviewNotificationList() {
+    val testModel = {
+        NotificationUiModel(
+            id = Random.nextLong(),
+            image =
+                "https://encrypted-tbn1.gstatic.com/" +
+                    "images?q=tbn:ANd9GcTRI8A6M23RTePWn8of5fgwRzSMMzRy" +
+                    "_6mZP7OrP79VF3ByzCoRcyfx6bYr9w4bH9zdVfpV" +
+                    "_LP9hBAudM5SRGyjnbbEhnrs2vWZKF8wySI",
+            user = "홍길동",
+            content = "님이 ㅋㅋㅋ 게시글에 답글을 추가했습니다.",
+            isRead = true,
+            type = NotificationType.SYSTEM,
+            senderId = 0,
+            studyGroupId = null,
+            studyGroupName = null,
+        )
+    }
+    val testList = List<NotificationUiModel>(500) { testModel() }
+    val fakeFlow = MutableStateFlow(PagingData.from(testList)).collectAsLazyPagingItems()
+
+    NeeGongNaeGongTheme {
+        NotificationList(
+            listState = rememberLazyListState(),
+            notificationList = fakeFlow,
+            onDeleteNotification = {},
+            onMoveNotification = {},
+            onAcceptGroupJoinRequest = {},
+            onRejectGroupJoinRequest = {},
+        )
     }
 }


### PR DESCRIPTION
## 📌 연결된 이슈
- #170 

### ✅ 작업 내용
- 로그인 성공 시 Nav 이동 관련 내용을 처리하던 MainNavGraph에 있던 로직을 MainActivity로 이동
- DeepLink가 들어있는 알림을 눌러서 앱 실행 시에, 로그인이 성공했으면 DeepLink의 적절한 경로로 이동하는 handleDeepLink 함수 실행하도록 로직 추가
- 앱만의 Domain 링크 검증 관련해서 Release 스토어, 키 생성 및 해당 키로 인증(O auth 쓰기 위해서 sha 값 이용하는 것과 동일)
- Foreground, Background 상관 없이 값을 수신할 수 있도록, 오직 data의 속성을 통해 title, body 등 수신
- 현재 deeplink로 이동하고자 했던 composable 관련해서 deeplink 경로 생성

### 📷 관련 이미지(영상)

|스터디 그룹|공지|투표|
|:--:|:--:|:--:|
|<video src="https://github.com/user-attachments/assets/3a56e0d0-9881-4f44-9045-61c8f188976b" alt="시연" controls>|<video src="https://github.com/user-attachments/assets/614f77d2-5dfb-425e-879a-851d4582e939" alt="시연" controls>|<video src="https://github.com/user-attachments/assets/592695e6-ca2d-45c4-9990-88afe0f0b974" alt="시연" controls>|



### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
- 투표 화면에서 살짝 깜박거리는 게 있는데 이건 `UI Loading` 관련해서 제가 아직 적용하지 않아서 그렇습니다
- 1차 MVP 끝내서 출시하면서 공부하고 대대적으로 리팩토링 들어갈 때 적용할 예정입니다
- 그 저희만의 `도메인 URL` 인증하려면 관련해서 파일에 `sha 값` 필요한데, 이걸 `release`에 있는 거로 넣어서, 아마 `release`로 빌드해야 제대로 작동할 거로 예상됩니다. `debug`에서도 하려면 `o auth` 위해 적어놨던 `sha` 값처럼 다른 걸 더 넣은 파일로 갱신해야 합니다
- 본 영상은 `release` 모드로 빌드된 app으로 테스트한 영상입니다
- `release`로 하니 사소한 거 하나 수정해도 다시 빌드하는데 좀 오래 걸리긴 하더군용 멀티 모듈로 빌드 시간을 단축시킬 수 있을 것으로 보입니다

@limnyn 