### PR TITLE
 기록 측정 화면 버그 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -46,6 +47,8 @@
 
         <activity
             android:name=".presentation.timer.TimerActivity"
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.NeeGongNaeGong"
             android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/TimerActivity.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/TimerActivity.kt
@@ -5,10 +5,12 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -60,10 +62,17 @@ class TimerActivity : ComponentActivity() {
 
         setContent {
             NeeGongNaeGongTheme {
-                Scaffold(snackbarHost = { NeeGongNaeGongSnackbarHost() }) { innerPadding ->
+                Scaffold(
+                    snackbarHost = { NeeGongNaeGongSnackbarHost() },
+                    containerColor = NeeGongNaeGongTheme.colorScheme.background,
+                ) { innerPadding ->
+                    Log.e("싸피", "onCreate: $innerPadding")
                     LearningRoute(
                         modifier =
-                            Modifier.padding(innerPadding),
+                            Modifier
+                                .padding(innerPadding)
+                                // imePadding()에서 bottomNavBar 크기만큼 패딩이 중복되는 것을 막기 위함
+                                .consumeWindowInsets(innerPadding),
                         viewModel = viewModel,
                         onCloseActivity = {
                             val resultIntent =
@@ -99,6 +108,7 @@ fun LearningRoute(
         )
     } else {
         LearningRecordWriteRoute(
+            modifier = modifier,
             learningRecord = uiState.learningRecord,
             onCloseActivity = onCloseActivity,
         )

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/component/write/DateTimeHeader.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/component/write/DateTimeHeader.kt
@@ -22,7 +22,7 @@ fun DateTimeHeader(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(top = 20.dp, start = 12.dp, end = 12.dp, bottom = 20.dp),
+                .padding(start = 12.dp, end = 12.dp, bottom = 20.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.Bottom,
     ) {

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/learning/LearningRecordWriteScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/learning/LearningRecordWriteScreen.kt
@@ -7,12 +7,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -113,8 +115,6 @@ fun LearningRecordWriteContent(
     // activity
     onCloseActivity: () -> Unit,
 ) {
-    val context = LocalContext.current
-
     LaunchedEffect(effect) {
         effect.collectLatest { effect ->
             when (effect) {
@@ -161,7 +161,6 @@ fun LearningRecordWriteContent(
 }
 
 // 처음에 태그 선택할때 (ex.CS,알고리즘.. ) user -> 관련스터디 -> 카테고리
-
 @Composable
 fun LearningRecordWriteScreen(
     modifier: Modifier = Modifier,
@@ -175,16 +174,18 @@ fun LearningRecordWriteScreen(
     onConfirmClicked: () -> Unit,
 ) {
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
-
+    val scroll = rememberScrollState()
     Column(
         modifier =
             modifier
                 .fillMaxSize()
                 .background(color = NeeGongNaeGongTheme.colorScheme.background)
-                .padding(top = 16.dp, start = 8.dp, end = 8.dp),
+                .imePadding().padding(start = 8.dp, end = 8.dp).verticalScroll(scroll),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        Column {
+        Column(
+            verticalArrangement = Arrangement.SpaceAround,
+        ) {
             DateTimeHeader(
                 dateText = learningRecord.startAt.toDateString(),
                 timeText = "${learningRecord.startAt.toTimeString()} ~ ${learningRecord.endAt.toTimeString()}",


### PR DESCRIPTION
## 📌 연결된 이슈
- #161

### ✅ 작업 내용
- Scaffold의 containerColor 명시적 지정으로 statusbar, bottomnavbar의 색이 화면과 통일되도록 설정
- 기록 입력 시 키보드 올라가면서 statusbar 영역을 침범하던 문제 수정

### 📷 관련 이미지(영상)
|Statusbar, navBar|기록 수정 키보드 화면|
|:--:|:--:|
|<img width="300" height="2376" alt="image" src="https://github.com/user-attachments/assets/fa091924-ae6b-4a52-8b88-def5c7d7d8ce" />|<video width="600px" src="https://github.com/user-attachments/assets/5207e318-db93-4516-849e-ac6e8d4020cd" />|




### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
- adjustResize와 Scaffold에서 innerPadding에는 statusbar와, bottomNavBar padding이 계산되어서 적용하면 침범할 일이 기본적으로 없습니다
- 다만 여기서만 끝나면, 만약 입력하고자 하는 텍스트 필드를 IME가 침범해도 별다른 상호작용이 없습니다. (스크롤을 내려서 가려져 있는 영역을 볼 수 있다던지)
- 이를 해결하려면 imePadding()을 적용하면 됩니다.
- 다만 IME Padding 영역이 키보드 아래의 bottomNavBar 영역도 포함해버려서 화면 아래, 키보드 위 사이에 불필요한 BottomNav 만큼의 중복 패딩이 생깁니다
- 이를 해결하려면 Scaffold에서 innerPadding을 적용하면서, 동시에 consumeInsets(innerPadding)으로 이미 statusBar와 BottomNav 패딩은 이미 적용됐다는 것을 알려서, imePadding에서 bottomNavPadding은 빼고서 순수하게 키보드 영역만 적용되도록 해야 합니다.
- 그리고 이렇게 밀려서 화면이 스크롤 가능하게 되었을 때 스크롤을 할 수 있도록 rememberScrollState 변수를 Column의 vertical scroll로 넣어서 키보드에 밀려 올라갔을 때 Scroll 가능하게 설정할 수 있습니다