### PR TITLE
그룹 이미지 로딩 실패 시 기본 이미지로 수정

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/StudiesWindow.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/StudiesWindow.kt
@@ -1,5 +1,6 @@
 package com.ssafy.neegongnaegong.presentation.group.component
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,8 +13,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -208,11 +207,9 @@ fun StudiesWindow(
                                         .fillMaxSize()
                                         .background(MaterialTheme.colorScheme.errorContainer),
                             ) {
-                                Icon(
-                                    imageVector = Icons.Default.Error,
-                                    contentDescription = "이미지 로드 실패",
-                                    modifier = Modifier.align(Alignment.Center),
-                                    tint = MaterialTheme.colorScheme.error,
+                                Image(
+                                    painter = painterResource(R.drawable.img_main_character),
+                                    contentDescription = "Group Profile Image",
                                 )
                             }
                         },

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/StudiesDrawer.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/StudiesDrawer.kt
@@ -276,13 +276,8 @@ private fun StudiesDrawer(
                             failure = {
                                 // 이미지 로드 실패 시 플레이스홀더
                                 Image(
-                                    painter = painterResource(id = R.drawable.img_default_profile),
-                                    contentDescription = "Profile Image",
-                                    modifier =
-                                        Modifier
-                                            .size(100.dp)
-                                            .clip(CircleShape),
-                                    contentScale = ContentScale.Crop,
+                                    painter = painterResource(id = R.drawable.img_main_character),
+                                    contentDescription = "Group Profile Image",
                                 )
                             },
                         )


### PR DESCRIPTION
## 📌 연결된 이슈
- #181 

### ✅ 작업 내용
- 스터디 리스트 볼 때 및 Drawer에서 내 스터디 볼 때 이미지 로딩 실패했을 때 기본 사진 변경

### 📷 관련 이미지(영상)
|리스트|드로워|
|:--:|:--:|
|<img width="480" alt="image" src="https://github.com/user-attachments/assets/6a940dce-bea0-40a6-bf7d-2ff8adac935e" />|<img width="480" alt="image" src="https://github.com/user-attachments/assets/91f4d448-2155-4c20-862a-9c2a64cc3a7c" />|

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
- 에러 사진은 스터디 그룹 정보 수정 관련할 때는 이미지 설정이 잘못됐다는 것을 명시적으로 표현하기 위해 좋은 것 같지만 리스트 볼 때 에러 사진이 뜨면 심미적으로 좋지 않을 것 같아 기본 이미지로 변경했습니다