### PR TITLE
그룹 삭제 로직 추가

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/StudiesDrawer.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/StudiesDrawer.kt
@@ -23,8 +23,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -69,7 +67,6 @@ fun StudiesDrawerContent(
     navigateToStudiesApplications: (Role) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    var showDeleteStudyGroupDialog by remember { mutableStateOf(false) }
     val myStudyList = viewModel.myStudyList.collectAsLazyPagingItems()
     val role = uiState.studyGroupDetailInfo.myGroupRole
     StudiesDrawer(
@@ -78,15 +75,16 @@ fun StudiesDrawerContent(
         description = uiState.studyGroupDetailInfo.description,
         role = role,
         myStudyList = myStudyList,
-        onStudyDeleteClick = { showDeleteStudyGroupDialog = true },
+        onStudyDeleteClick = { viewModel.setEvent(StudiesDetailContract.Event.OnDeleteMenuClick) },
         navigateTodStudiesEdit = { navigateTodStudiesEdit(role) },
         navigateToStudiesMembersRole = { navigateToStudiesMembersRole(role) },
         navigateToStudiesApplications = { navigateToStudiesApplications(role) },
     )
-    if (showDeleteStudyGroupDialog) {
+
+    if (uiState.showDeleteDialog) {
         DeleteStudiesDialog(
-            onCancel = { showDeleteStudyGroupDialog = false },
-            onDismiss = { showDeleteStudyGroupDialog = false },
+            onCancel = { viewModel.setEvent(StudiesDetailContract.Event.OnDeleteDialogDismiss) },
+            onDismiss = { viewModel.setEvent(StudiesDetailContract.Event.OnDeleteDialogDismiss) },
             onConfirm = {
                 viewModel.setEvent(
                     StudiesDetailContract.Event.OndDeleteStudies(uiState.studyGroupDetailInfo.id),

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailContract.kt
@@ -49,10 +49,15 @@ class StudiesDetailContract {
         data class OnClickProfile(
             val memberId: Long,
         ) : Event
+
+        data object OnDeleteMenuClick : Event
+
+        data object OnDeleteDialogDismiss : Event
     }
 
     data class State(
         val isLoading: Boolean = false,
+        val showDeleteDialog: Boolean = false,
         val studyGroupDetailInfo: StudyGroupDetailInfo =
             StudyGroupDetailInfo(
                 id = 8666,
@@ -108,6 +113,8 @@ class StudiesDetailContract {
         data class NavigateToProfile(
             val memberId: Long,
         ) : Effect
+
+        data object NavigateToMain : Effect
     }
 
     sealed interface Error : ErrorContext

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailScreen.kt
@@ -44,6 +44,7 @@ fun StudiesDetailRoute(
     navigateToLatestNoticeDetail: (Long, Long) -> Unit,
     navigateToLatestVoteDetail: (Long, Long) -> Unit,
     navigateToMemberRecord: (Long) -> Unit,
+    navigateToMain: () -> Unit,
     popBackStack: () -> Unit = {},
 ) {
     val currentDrawerState = LocalDrawerState.current
@@ -91,6 +92,12 @@ fun StudiesDetailRoute(
 
                 is StudiesDetailContract.Effect.NavigateToProfile ->
                     navigateToMemberRecord(effect.memberId)
+
+                StudiesDetailContract.Effect.NavigateToMain -> {
+                    currentDrawerState.snapTo(DrawerValue.Closed)
+
+                    navigateToMain()
+                }
             }
         }
     }
@@ -182,7 +189,10 @@ private fun StudiesDetailScreen(
 ) {
     val scope = rememberCoroutineScope()
     Column(
-        modifier = modifier.fillMaxSize().background(color = NeeGongNaeGongTheme.colorScheme.gray2),
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(color = NeeGongNaeGongTheme.colorScheme.gray2),
     ) {
         // 커스텀 앱바
         TopAppBar(

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailViewModel.kt
@@ -54,7 +54,9 @@ class StudiesDetailViewModel
                 is StudiesDetailContract.Event.OnLoadFeeds -> onLoadFeeds(event.studyGroupId)
                 is StudiesDetailContract.Event.OnLoadWeeklyRankings -> onLoadWeeklyRankings(event.studyGroupId)
                 is StudiesDetailContract.Event.OnLoadLatestContents -> onLoadLatestContents(event.studyGroupId)
-                is StudiesDetailContract.Event.OndDeleteStudies -> deleteStudies(event.studyGroupId)
+                is StudiesDetailContract.Event.OndDeleteStudies -> {
+                    deleteStudies(event.studyGroupId)
+                }
                 is StudiesDetailContract.Event.OnClickLatestNotice -> {
                     setEffect {
                         StudiesDetailContract.Effect.NavigateToLatestNoticeDetail(
@@ -88,6 +90,10 @@ class StudiesDetailViewModel
                         )
                     }
                 }
+
+                StudiesDetailContract.Event.OnDeleteDialogDismiss -> setState { copy(showDeleteDialog = false) }
+
+                StudiesDetailContract.Event.OnDeleteMenuClick -> setState { copy(showDeleteDialog = true) }
             }
         }
 
@@ -179,7 +185,8 @@ class StudiesDetailViewModel
                     .withLoading {
                         setState { copy(isLoading = it) }
                     }.safeCollect {
-                        showMessage("스터디가 삭제되었습니다.")
+                        showSuccessMessage("스터디가 삭제되었습니다.")
+                        setEffect { StudiesDetailContract.Effect.NavigateToMain }
                     }
             }
         }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/MainNavigationGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/MainNavigationGraph.kt
@@ -1,5 +1,7 @@
 package com.ssafy.neegongnaegong.presentation.navigation
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.navigation.NavHostController
@@ -11,6 +13,8 @@ fun MainNavigationGraph(navController: NavHostController) {
     NavHost(
         navController = navController,
         startDestination = "splash",
+        popExitTransition = { ExitTransition.None },
+        enterTransition = { EnterTransition.None },
     ) {
         composable("splash") {}
         authNavGraph(navController)

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/navigation/StudiesNavGraph.kt
@@ -110,6 +110,15 @@ fun NavGraphBuilder.studiesNavGraph(navController: NavController) {
                             ),
                         )
                     },
+                    navigateToMain = {
+                        navController.navigate(
+                            AppNavigation.Screen.Studies.Main,
+                        ) {
+                            popUpTo<AppNavigation.Screen.Studies.Main> {
+                                inclusive = true
+                            }
+                        }
+                    },
                     popBackStack = navController::popBackStack,
                 )
             }


### PR DESCRIPTION
## 📌 연결된 이슈
- #183 

### ✅ 작업 내용
- 삭제 눌렀을 때, Drawer 닫고 Main으로 이동하도록 수정

### 📷 관련 이미지(영상)

https://github.com/user-attachments/assets/236e7b17-1105-480b-a8d4-6cc869e8ba80


### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
- 다이얼로그 삭제시에 API 호출만 하고 말았었네요
- 성공했을 때 Main으로 이동하도록 로직 추가했습니다
- 추가적으로 Nav Effect 관련해서 없애달라고 해서, Transition을 전부 None으로 처리했습니다