### PR TITLE
공부 기록 태그 삭제 버그 해결

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/edit/StudyRecordEditViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/edit/StudyRecordEditViewModel.kt
@@ -163,17 +163,12 @@ class StudyRecordEditViewModel
         private fun clearDialogTags() = setState { copy(selectedTags = emptyList(), unSelectedTags = emptyList()) }
 
         private fun moveFromSelectedTagsToTags() {
-            val tags = uiState.value.tags.toSet()
-            val selected = uiState.value.selectedTags.toSet()
-
-            val merged = tags + selected
-
             setState {
                 copy(
-                    tags = merged.toList(),
+                    tags = uiState.value.selectedTags,
                     selectedTags = emptyList(),
                     unSelectedTags = emptyList(),
-                    learningRecord = learningRecord.copy(tags = merged.toList()),
+                    learningRecord = learningRecord.copy(tags = uiState.value.selectedTags),
                 )
             }
         }
@@ -188,7 +183,18 @@ class StudyRecordEditViewModel
 
         private fun deleteTag(tag: Tag) {
             val newTags = uiState.value.tags - tag
-            setState { copy(tags = newTags) }
+            setState {
+                copy(
+                    tags = newTags,
+                    learningRecord = learningRecord.copy(tags = newTags),
+                )
+            }
+            setState {
+                copy(
+                    selectedTags = uiState.value.selectedTags - tag,
+                    unSelectedTags = uiState.value.unSelectedTags + tag,
+                )
+            }
         }
 
         private fun selectTag(tag: Tag) {

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/edit/StudyRecordEditViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/edit/StudyRecordEditViewModel.kt
@@ -187,10 +187,6 @@ class StudyRecordEditViewModel
                 copy(
                     tags = newTags,
                     learningRecord = learningRecord.copy(tags = newTags),
-                )
-            }
-            setState {
-                copy(
                     selectedTags = uiState.value.selectedTags - tag,
                     unSelectedTags = uiState.value.unSelectedTags + tag,
                 )

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/learning/LearningRecordWriteViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/learning/LearningRecordWriteViewModel.kt
@@ -133,17 +133,12 @@ class LearningRecordWriteViewModel
         private fun clearDialogTags() = setState { copy(selectedTags = emptyList(), unSelectedTags = emptyList()) }
 
         private fun moveFromSelectedTagsToTags() {
-            val tags = uiState.value.tags.toSet()
-            val selected = uiState.value.selectedTags.toSet()
-
-            val merged = tags + selected
-
             setState {
                 copy(
-                    tags = merged.toList(),
+                    tags = uiState.value.selectedTags,
                     selectedTags = emptyList(),
                     unSelectedTags = emptyList(),
-                    learningRecord = learningRecord.copy(tags = merged.toList()),
+                    learningRecord = learningRecord.copy(tags = uiState.value.selectedTags),
                 )
             }
         }
@@ -158,7 +153,18 @@ class LearningRecordWriteViewModel
 
         private fun deleteTag(tag: Tag) {
             val newTags = uiState.value.tags - tag
-            setState { copy(tags = newTags) }
+            setState {
+                copy(
+                    tags = newTags,
+                    learningRecord = learningRecord.copy(tags = newTags),
+                )
+            }
+            setState {
+                copy(
+                    selectedTags = uiState.value.selectedTags - tag,
+                    unSelectedTags = uiState.value.unSelectedTags + tag,
+                )
+            }
         }
 
         private fun selectTag(tag: Tag) {

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/learning/LearningRecordWriteViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/learning/LearningRecordWriteViewModel.kt
@@ -143,7 +143,7 @@ class LearningRecordWriteViewModel
                     tags = merged.toList(),
                     selectedTags = emptyList(),
                     unSelectedTags = emptyList(),
-                    learningRecord = learningRecord.copy(tags = merged.toList())
+                    learningRecord = learningRecord.copy(tags = merged.toList()),
                 )
             }
         }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/learning/LearningRecordWriteViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/timer/learning/LearningRecordWriteViewModel.kt
@@ -157,10 +157,6 @@ class LearningRecordWriteViewModel
                 copy(
                     tags = newTags,
                     learningRecord = learningRecord.copy(tags = newTags),
-                )
-            }
-            setState {
-                copy(
                     selectedTags = uiState.value.selectedTags - tag,
                     unSelectedTags = uiState.value.unSelectedTags + tag,
                 )


### PR DESCRIPTION
## 📌 연결된 이슈
- #204

### ✅ 작업 내용
- 공부 기록 태그 리스트에서 삭제 버그 해결
- 공부 기록 다이어로그 태그 삭제 버그 해결
- 공부 기록 (수정, 생성) 화면 버그 해결


### 📷 관련 이미지(영상)
두 곳의 로직이 똑같기 때문에 먼저 공부기록 수정화면에서 버그를 해결하고 비교했습니다.
- 수정 전
  - 생성화면에서 진행된 상태는 다이어로그에서 태그를 삭제시에 반영되지 않는 현상
  - 밑에 태그리스트에서 삭제를 했는데 반영되지 않고 생성되는 현상
- 수정 후
  - 수정화면에서 진행된 상태는 다이어로그에서 태그를 삭제시 반영되어 해결
  - 밑에 태그리스트에서 삭제하고 수정되어 해결

| 수정 전 | 수정 후 |
| ---- | ---- |
| <img src="https://github.com/user-attachments/assets/1db36bd9-756e-4e54-9f90-934ec8df57bd" width="300"> | <img src="https://github.com/user-attachments/assets/422732d4-7e50-4cec-9baf-816ed9c0e2f2" width="300"> |

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
f1fa38c36d5b9fa0bfce21ce296560bfd59c21c5 커밋에 실수로 생성화면 ViewModel의 콤마하나 수정된게 반영되어 있습니다.

위 버그가 생겼던 요인은 아마 생성 화면과 수정 화면을 처음에는 하나로 생각하고 작업을 하다가 생성 화면에 초점을 맞추어 **Contract**에 있는 `tags` **state**가 따로 존재하여 발생한 문제로 예상됩니다.
생성 화면에서는 `learningLecord`라는 데이터가 따로 없어서 `tags`로 관리했고 이에 `learningLecord`안에 `tags`와 `tags` 두 가지가 사용되어 예상치 못한 문제를 발생시킨 것 같습니다.
**ViewModel**에 있는 이벤트 함수들이 불안전했던 것으로 조금 수정을 해서 버그는 해결했습니다.
현재는 로직상 문제는 없지만, 추후 하나로 통합해서 작성하는 개선작업이 필요해 보이긴 합니다.

@Na2te 
close #204
