### PR TITLE
익명 투표의 결과를 못보던 버그 수정

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/component/OptionButton.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/list/vote/component/OptionButton.kt
@@ -102,14 +102,12 @@ fun OptionButton(
                         color = NeeGongNaeGongTheme.colorScheme.primaryText,
                     )
                 }
-                if ((alreadyVoted || !state) && !isAnonymous) {
+                if (alreadyVoted || !state) {
                     Row(
                         modifier =
                             Modifier
                                 .wrapContentSize()
-                                .clickable {
-                                    onClickPersonList()
-                                },
+                                .clickable { if (!isAnonymous) onClickPersonList() },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         val iconSizeDp: Dp =
@@ -124,16 +122,18 @@ fun OptionButton(
                             style = NeeGongNaeGongTheme.typography.labelSmall,
                             color = NeeGongNaeGongTheme.colorScheme.gray4,
                         )
-                        Icon(
-                            modifier = Modifier.size(iconSizeDp),
-                            imageVector = Icons.Filled.ArrowDropDown,
-                            tint = NeeGongNaeGongTheme.colorScheme.primaryText,
-                            contentDescription = "투표한 사람 목록",
-                        )
+                        if (!isAnonymous) {
+                            Icon(
+                                modifier = Modifier.size(iconSizeDp),
+                                imageVector = Icons.Filled.ArrowDropDown,
+                                tint = NeeGongNaeGongTheme.colorScheme.primaryText,
+                                contentDescription = "투표한 사람 목록",
+                            )
+                        }
                     }
                 }
             }
-            if ((alreadyVoted || !state) && !isAnonymous) {
+            if (alreadyVoted || !state) {
                 Box(
                     modifier =
                         Modifier
@@ -185,6 +185,24 @@ fun PreviewOptionButtonEditMode() {
             votedUsers = listOf(StudyGroupVoteStatusInfo.VotedMemberInfo(0, ",", "")),
             optionTitle = "종료 시간",
             castMode = true,
+            onClick = {},
+        ) {}
+    }
+}
+
+@NeeGongNaeGongPreviews
+@Composable
+fun PreviewOptionButtonAnonymousMode() {
+    NeeGongNaeGongTheme {
+        OptionButton(
+            isSelected = true,
+            progress = 0.3F,
+            alreadyVoted = true,
+            state = false,
+            isAnonymous = true,
+            votedUsers = listOf(StudyGroupVoteStatusInfo.VotedMemberInfo(0, ",", "")),
+            optionTitle = "종료 시간",
+            castMode = false,
             onClick = {},
         ) {}
     }


### PR DESCRIPTION
## 📌 연결된 이슈
- #206 

### ✅ 작업 내용
- 실명 투표의 경우 결과가 끝날 경우 투표 참여 여부와 상관 없이 결과를 볼 수 있었지만 익명 투표의 경우 결과가 끝나더라도 투표 항목당 몇 명이 투표했는지조차 확인할 수가 없던 문제를 수정
- 몇 명이 투표했는지는 볼 수 있지만, 누가 투표했는지는 볼 수 없도록 설정

### 📷 관련 이미지(영상)

|수정 전|수정 후|
|:--:|:--:|
|<img width="968" height="2376" alt="image" src="https://github.com/user-attachments/assets/4c815cf0-21f8-4f4e-b871-ce3eed848377" />|<img width="968" height="2376" alt="image" src="https://github.com/user-attachments/assets/a48e3bc8-30da-491b-b8cc-801c6f73b62c" />|
### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
