### PR TITLE
태그별 학습 시간 표현 로직 수정

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordScreen.kt
@@ -89,6 +89,7 @@ fun RecordRoute(
                 Text(
                     text = "이번주 공부내용",
                     style = NeeGongNaeGongTheme.typography.titleSmall,
+                    color = NeeGongNaeGongTheme.colorScheme.primaryText,
                 )
             },
             onNavigationClick = { popBackStack() },

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordScreen.kt
@@ -275,7 +275,7 @@ fun ChartLegendScreen(
                             Modifier
                                 .size(12.dp)
                                 .clip(CircleShape)
-                                .background(color[index % 4]),
+                                .background(color[index % 5]),
                         )
                         Spacer(Modifier.width(8.dp))
                         Column {

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/record/RecordScreen.kt
@@ -96,7 +96,7 @@ fun RecordRoute(
 
         RecordContent(
             modifier
-                .weight(1F),
+                .weight(1F).padding(horizontal = 15.dp),
             pagingItem,
             uiState,
         )
@@ -122,7 +122,6 @@ fun RecordContent(
 
     Column(modifier = modifier) {
         Row(
-            modifier = Modifier.padding(horizontal = 15.dp),
             horizontalArrangement = Arrangement.Center,
         ) {
             PieChartScreen(

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/ui/theme/Type.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/ui/theme/Type.kt
@@ -23,6 +23,7 @@ data class Typography(
             fontWeight = FontWeight.Bold,
             fontSize = 28.sp,
             letterSpacing = letterSpacing,
+            fontFeatureSettings = "tnum",
         ),
     val titleMedium: TextStyle =
         TextStyle(
@@ -30,6 +31,7 @@ data class Typography(
             fontWeight = FontWeight.Bold,
             fontSize = 24.sp,
             letterSpacing = letterSpacing,
+            fontFeatureSettings = "tnum",
         ),
     val titleSmall: TextStyle =
         TextStyle(
@@ -37,6 +39,7 @@ data class Typography(
             fontWeight = FontWeight.Bold,
             fontSize = 20.sp,
             letterSpacing = letterSpacing,
+            fontFeatureSettings = "tnum",
         ),
     val bodyLarge: TextStyle =
         TextStyle(
@@ -44,6 +47,7 @@ data class Typography(
             fontWeight = FontWeight.SemiBold,
             fontSize = 20.sp,
             letterSpacing = letterSpacing,
+            fontFeatureSettings = "tnum",
         ),
     val bodyMedium: TextStyle =
         TextStyle(
@@ -51,6 +55,7 @@ data class Typography(
             fontWeight = FontWeight.SemiBold,
             fontSize = 18.sp,
             letterSpacing = letterSpacing,
+            fontFeatureSettings = "tnum",
         ),
     val bodySmall: TextStyle =
         TextStyle(
@@ -58,6 +63,7 @@ data class Typography(
             fontWeight = FontWeight.SemiBold,
             fontSize = 16.sp,
             letterSpacing = letterSpacing,
+            fontFeatureSettings = "tnum",
         ),
     val labelLarge: TextStyle =
         TextStyle(
@@ -65,6 +71,7 @@ data class Typography(
             fontWeight = FontWeight.Normal,
             fontSize = 16.sp,
             letterSpacing = letterSpacing,
+            fontFeatureSettings = "tnum",
         ),
     val labelMedium: TextStyle =
         TextStyle(
@@ -72,6 +79,7 @@ data class Typography(
             fontWeight = FontWeight.Normal,
             fontSize = 14.sp,
             letterSpacing = letterSpacing,
+            fontFeatureSettings = "tnum",
         ),
     val labelSmall: TextStyle =
         TextStyle(
@@ -79,5 +87,6 @@ data class Typography(
             fontWeight = FontWeight.Normal,
             fontSize = 12.sp,
             letterSpacing = letterSpacing,
+            fontFeatureSettings = "tnum",
         ),
 )

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/util/CustomDateTimeFormatter.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/util/CustomDateTimeFormatter.kt
@@ -127,7 +127,7 @@ object CustomDateTimeFormatter {
         return if (days > 0) {
             String.format(
                 Locale.getDefault(),
-                "%02dD%02dH%02dM",
+                "%2dd%2dh%2dm",
                 days,
                 hours,
                 minutes,
@@ -135,14 +135,14 @@ object CustomDateTimeFormatter {
         } else if (hours > 0) {
             String.format(
                 Locale.getDefault(),
-                "%02dH%02dM",
+                "%2dh%2dm",
                 hours,
                 minutes,
             )
         } else if (minutes > 0) {
-            String.format(Locale.getDefault(), "%02dM", minutes)
+            String.format(Locale.getDefault(), "%2dm", minutes)
         } else {
-            String.format(Locale.getDefault(), "%02dS", seconds)
+            String.format(Locale.getDefault(), "%2ds", seconds)
         }
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/util/CustomDateTimeFormatter.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/util/CustomDateTimeFormatter.kt
@@ -112,16 +112,37 @@ object CustomDateTimeFormatter {
     }
 
     /**
-     * 밀리초로 들어온 기간을 00H00M으로 바꾸기 위한 함수
+     * 초로 들어온 기간을 00H00M으로 바꾸기 위한 함수
      * @param Long 기간
      * @return String 00H00M 꼴
      */
     @SuppressLint("DefaultLocale")
-    fun formatDurationToHM(millis: Long): String {
-        val totalMinutes = millis / (1000 * 60)
-        val hours = totalMinutes / 60
+    fun formatDurationToHM(seconds: Long): String {
+        val totalMinutes = seconds / 60
+        val totalHours = totalMinutes / 60
+        val days = totalHours / 24
+        val hours = totalHours % 24
         val minutes = totalMinutes % 60
 
-        return String.format(Locale.getDefault(), "%02dH%02dM", hours, minutes)
+        return if (days > 0) {
+            String.format(
+                Locale.getDefault(),
+                "%02dD%02dH%02dM",
+                days,
+                hours,
+                minutes,
+            )
+        } else if (hours > 0) {
+            String.format(
+                Locale.getDefault(),
+                "%02dH%02dM",
+                hours,
+                minutes,
+            )
+        } else if (minutes > 0) {
+            String.format(Locale.getDefault(), "%02dM", minutes)
+        } else {
+            String.format(Locale.getDefault(), "%02dS", seconds)
+        }
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/util/CustomDateTimeFormatter.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/util/CustomDateTimeFormatter.kt
@@ -127,7 +127,7 @@ object CustomDateTimeFormatter {
         return if (days > 0) {
             String.format(
                 Locale.getDefault(),
-                "%2dd%2dh%2dm",
+                "%2dd %2dh %2dm",
                 days,
                 hours,
                 minutes,
@@ -135,7 +135,7 @@ object CustomDateTimeFormatter {
         } else if (hours > 0) {
             String.format(
                 Locale.getDefault(),
-                "%2dh%2dm",
+                "%2dh %2dm",
                 hours,
                 minutes,
             )


### PR DESCRIPTION
## 📌 연결된 이슈
- #196 

### ✅ 작업 내용
- 로직이 없거나 버그가 아니라, 전에 공부한 기간을 밀리 초 단위로 줬었었는데, 어느새 초 단위로 바뀌어 있어서 1000으로 나누는 바람에 발생한 원인이었음을 확인
- 만약 일 단위가 아니라면 시간과 분만, 시간 단위가 아니라면 분만, 분 단위도 아니라면 초만 표시하도록 설정
- 스터디 기록 카드에 여백 추가

### 📷 관련 이미지(영상)
<img width="300" height="2376" alt="image" src="https://github.com/user-attachments/assets/b6ba5875-dbc0-43b4-8e67-89efde2ab741" />

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
