### PR TITLE
공부기록 다건 삭제 구현

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkLearningRecordDataSource.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkLearningRecordDataSource.kt
@@ -1,6 +1,7 @@
 package com.ssafy.neegongnaegong.data.datasource.network
 
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.CreateLearningRecordRequest
+import com.ssafy.neegongnaegong.data.model.learningrecord.request.DeleteSelectedLearningRecordsRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.GetLearningRecordListRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.UpdateLearningRecordRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.response.CursorSliceResponse
@@ -15,6 +16,8 @@ interface NetworkLearningRecordDataSource {
     ): Flow<Unit>
 
     fun deleteLearningRecord(learningRecordId: Long): Flow<Unit>
+
+    fun deleteSelectedLearningRecords(request: DeleteSelectedLearningRecordsRequest): Flow<Unit>
 
     fun getLearningRecord(learningRecordId: Long): Flow<GetLearningRecordResponse>
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkLearningRecordDataSourceImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkLearningRecordDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.ssafy.neegongnaegong.data.datasource.network
 
 import com.ssafy.neegongnaegong.data.model.apiFlow
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.CreateLearningRecordRequest
+import com.ssafy.neegongnaegong.data.model.learningrecord.request.DeleteSelectedLearningRecordsRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.GetLearningRecordListRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.UpdateLearningRecordRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.response.CursorSliceResponse
@@ -22,6 +23,9 @@ class NetworkLearningRecordDataSourceImpl
         ): Flow<Unit> = apiFlow { api.updateLearningRecord(learningRecordId, request) }
 
         override fun deleteLearningRecord(learningRecordId: Long): Flow<Unit> = apiFlow { api.deleteLearningRecord(learningRecordId) }
+
+        override fun deleteSelectedLearningRecords(request: DeleteSelectedLearningRecordsRequest): Flow<Unit> =
+            apiFlow { api.deleteSelectedLearningRecords(request = request) }
 
         override fun getLearningRecord(learningRecordId: Long): Flow<GetLearningRecordResponse> =
             apiFlow { api.getLearningRecord(learningRecordId) }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/learningrecord/LearningRecordMapper.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/learningrecord/LearningRecordMapper.kt
@@ -2,6 +2,7 @@ package com.ssafy.neegongnaegong.data.mapper.learningrecord
 
 import com.ssafy.neegongnaegong.data.mapper.tag.LearningRecordTagMapper.toDomain
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.CreateLearningRecordRequest
+import com.ssafy.neegongnaegong.data.model.learningrecord.request.DeleteSelectedLearningRecordsRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.UpdateLearningRecordRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.response.AuthorResponse
 import com.ssafy.neegongnaegong.data.model.learningrecord.response.GetLearningRecordDatesByMonthResponse
@@ -51,5 +52,10 @@ internal object LearningRecordMapper {
             id = id,
             nickname = username,
             profileImg = profileImg,
+        )
+
+    fun List<Long>.toDeleteSelectedRequest() =
+        DeleteSelectedLearningRecordsRequest(
+            recordIds = this,
         )
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/learningrecord/request/DeleteSelectedLearningRecordsRequest.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/learningrecord/request/DeleteSelectedLearningRecordsRequest.kt
@@ -1,0 +1,5 @@
+package com.ssafy.neegongnaegong.data.model.learningrecord.request
+
+data class DeleteSelectedLearningRecordsRequest(
+    val recordIds: List<Long>,
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/remote/LearningRecordApi.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/remote/LearningRecordApi.kt
@@ -2,6 +2,7 @@ package com.ssafy.neegongnaegong.data.remote
 
 import com.ssafy.neegongnaegong.data.model.ApiResponse
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.CreateLearningRecordRequest
+import com.ssafy.neegongnaegong.data.model.learningrecord.request.DeleteSelectedLearningRecordsRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.request.UpdateLearningRecordRequest
 import com.ssafy.neegongnaegong.data.model.learningrecord.response.CursorSliceResponse
 import com.ssafy.neegongnaegong.data.model.learningrecord.response.GetLearningRecordDatesByMonthResponse
@@ -15,28 +16,33 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface LearningRecordApi {
-    @PUT("/api/records/{learning-record-id}")
+    @PUT("$PREFIX/{learning-record-id}")
     suspend fun updateLearningRecord(
         @Path("learning-record-id") learningRecordId: Long,
         @Body request: UpdateLearningRecordRequest,
     ): Result<ApiResponse<Unit>>
 
-    @DELETE("api/records/{learning-record-id}")
+    @DELETE("$PREFIX/{learning-record-id}")
     suspend fun deleteLearningRecord(
         @Path("learning-record-id") learningRecordId: Long,
     ): Result<ApiResponse<Unit>>
 
-    @GET("/api/records/{learning-record-id}")
+    @DELETE(PREFIX)
+    suspend fun deleteSelectedLearningRecords(
+        @Body request: DeleteSelectedLearningRecordsRequest,
+    ): Result<ApiResponse<Unit>>
+
+    @GET("$PREFIX/{learning-record-id}")
     suspend fun getLearningRecord(
         @Path("learning-record-id") learningRecordId: Long,
     ): Result<ApiResponse<GetLearningRecordResponse>>
 
-    @POST("/api/records")
+    @POST(PREFIX)
     suspend fun createLearningRecord(
         @Body request: CreateLearningRecordRequest,
     ): Result<ApiResponse<Long>>
 
-    @GET("/api/records/list")
+    @GET("$PREFIX/list")
     suspend fun getLearningRecordList(
         @Query("tag") tag: List<Long>?,
         @Query("target-date") targetDate: String?,
@@ -45,8 +51,12 @@ interface LearningRecordApi {
         @Query("size") size: Int,
     ): Result<ApiResponse<CursorSliceResponse>>
 
-    @GET("/api/records/date/{year-month}")
+    @GET("$PREFIX/date/{year-month}")
     suspend fun getLearningRecordDatesByMonth(
         @Path("year-month") yearMonth: String,
     ): Result<ApiResponse<GetLearningRecordDatesByMonthResponse>>
+
+    companion object {
+        const val PREFIX = "/api/records"
+    }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/remote/LearningRecordApi.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/remote/LearningRecordApi.kt
@@ -10,6 +10,7 @@ import com.ssafy.neegongnaegong.data.model.learningrecord.response.GetLearningRe
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -27,7 +28,7 @@ interface LearningRecordApi {
         @Path("learning-record-id") learningRecordId: Long,
     ): Result<ApiResponse<Unit>>
 
-    @DELETE(PREFIX)
+    @HTTP(method = "DELETE", path = PREFIX, hasBody = true)
     suspend fun deleteSelectedLearningRecords(
         @Body request: DeleteSelectedLearningRecordsRequest,
     ): Result<ApiResponse<Unit>>

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/repository/LearningRecordRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/repository/LearningRecordRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.ssafy.neegongnaegong.data.repository
 
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkLearningRecordDataSource
 import com.ssafy.neegongnaegong.data.mapper.learningrecord.LearningRecordMapper.toCreateRequest
+import com.ssafy.neegongnaegong.data.mapper.learningrecord.LearningRecordMapper.toDeleteSelectedRequest
 import com.ssafy.neegongnaegong.data.mapper.learningrecord.LearningRecordMapper.toDomain
 import com.ssafy.neegongnaegong.data.mapper.learningrecord.LearningRecordMapper.toLocalDates
 import com.ssafy.neegongnaegong.data.mapper.learningrecord.LearningRecordMapper.toUpdateRequest
@@ -38,6 +39,12 @@ class LearningRecordRepositoryImpl
             dataSource
                 .deleteLearningRecord(
                     learningRecordId = learningRecordId,
+                ).flowOn(context = ioDispatcher)
+
+        override fun deleteSelectedLearningRecords(recordIds: List<Long>): Flow<Unit> =
+            dataSource
+                .deleteSelectedLearningRecords(
+                    request = recordIds.toDeleteSelectedRequest(),
                 ).flowOn(context = ioDispatcher)
 
         override suspend fun updateLearningRecord(

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/LearningRecordRepository.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/LearningRecordRepository.kt
@@ -12,6 +12,8 @@ interface LearningRecordRepository {
 
     fun deleteLearningRecord(learningRecordId: Long): Flow<Unit>
 
+    fun deleteSelectedLearningRecords(recordIds: List<Long>): Flow<Unit>
+
     suspend fun updateLearningRecord(
         learningRecordId: Long,
         learningRecord: LearningRecord,

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/learningrecord/DeleteSelectedLearningRecordsUseCase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/learningrecord/DeleteSelectedLearningRecordsUseCase.kt
@@ -1,0 +1,13 @@
+package com.ssafy.neegongnaegong.domain.usecase.learningrecord
+
+import com.ssafy.neegongnaegong.domain.repository.LearningRecordRepository
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+class DeleteSelectedLearningRecordsUseCase
+    @Inject
+    constructor(
+        private val repository: LearningRecordRepository,
+    ) {
+        operator fun invoke(recordIds: List<Long>): Flow<Unit> = repository.deleteSelectedLearningRecords(recordIds)
+    }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordItem.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordItem.kt
@@ -15,14 +15,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
@@ -43,12 +47,21 @@ import com.ssafy.neegongnaegong.presentation.util.toTimeString
 fun StudyRecordItem(
     record: LearningRecord,
     isStudyFeed: Boolean = false,
+    isSelectedMode: Boolean = false,
+    isDeleteSelected: Boolean = false,
     onClick: (Long) -> Unit = {},
+    onDeleteSelect: (Long) -> Unit = {},
 ) {
     if (isStudyFeed) {
         StudyFeedItem(record, onClick)
     } else {
-        PersonalRecordItem(record, onClick)
+        PersonalRecordItem(
+            record = record,
+            isSelectedMode = isSelectedMode,
+            isDeleteSelected = isDeleteSelected,
+            onClick = onClick,
+            onDeleteSelect = onDeleteSelect,
+        )
     }
 }
 
@@ -56,8 +69,12 @@ fun StudyRecordItem(
 @Composable
 private fun PersonalRecordItem(
     record: LearningRecord,
+    isSelectedMode: Boolean = false,
+    isDeleteSelected: Boolean = false,
     onClick: (Long) -> Unit = {},
+    onDeleteSelect: (Long) -> Unit = {},
 ) {
+    val currentAlpha = if (isDeleteSelected) 0.5f else 1.0f
     Box(
         modifier =
             Modifier
@@ -66,7 +83,13 @@ private fun PersonalRecordItem(
                 .background(
                     NeeGongNaeGongTheme.colorScheme.recordBackground,
                     RoundedCornerShape(8.dp),
-                ).clickable(onClick = { onClick(record.id) })
+                ).clickable(onClick = {
+                    if (isSelectedMode) {
+                        onDeleteSelect(record.id)
+                    } else {
+                        onClick(record.id)
+                    }
+                })
                 .padding(16.dp),
     ) {
         Column {
@@ -76,8 +99,23 @@ private fun PersonalRecordItem(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                if (isSelectedMode) {
+                    Checkbox(
+                        modifier = Modifier.requiredSize(16.dp).padding(end = 8.dp),
+                        checked = isDeleteSelected,
+                        onCheckedChange = {
+                            onDeleteSelect(record.id)
+                        },
+                        colors =
+                            CheckboxDefaults.colors(
+                                checkedColor = NeeGongNaeGongTheme.colorScheme.blue,
+                                uncheckedColor = NeeGongNaeGongTheme.colorScheme.primaryText,
+                                checkmarkColor = NeeGongNaeGongTheme.colorScheme.primaryText,
+                            ),
+                    )
+                }
                 Text(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).alpha(currentAlpha),
                     text = record.title.ifBlank { "제목을 설정해주세요." },
                     style = NeeGongNaeGongTheme.typography.titleMedium.copy(fontSize = 20.sp),
                     maxLines = 1,
@@ -91,6 +129,7 @@ private fun PersonalRecordItem(
                 val end = record.endAt.toHourMinuteString()
 
                 Text(
+                    modifier = Modifier.alpha(currentAlpha),
                     text = "$start ~ $end",
                     style =
                         NeeGongNaeGongTheme.typography.bodySmall.copy(
@@ -104,6 +143,7 @@ private fun PersonalRecordItem(
 
             // 내용
             Text(
+                modifier = Modifier.alpha(currentAlpha),
                 text = record.content.ifBlank { "내용을 설정해주세요" },
                 style = NeeGongNaeGongTheme.typography.bodySmall.copy(fontSize = 12.sp),
                 maxLines = 4,
@@ -114,7 +154,10 @@ private fun PersonalRecordItem(
             Spacer(modifier = Modifier.height(12.dp))
 
             // 태그
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            FlowRow(
+                modifier = Modifier.alpha(currentAlpha),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
                 record.tags.forEach { tag ->
                     Text(
                         text = "#${tag.koName}",

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordList.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordList.kt
@@ -40,6 +40,10 @@ fun StudyRecordList(
     onLoadMore: () -> Unit,
     hasNext: Boolean,
     isStudyFeed: Boolean = false,
+    // delete selected
+    isSelectedMode: Boolean = false,
+    deleteSelectedRecordIds: Set<Long> = setOf(),
+    onDeleteSelect: (Long) -> Unit = {},
 ) {
     if (learningRecords.isEmpty()) {
         Box(
@@ -95,7 +99,14 @@ fun StudyRecordList(
                 }
 
                 items(recordsForDate) { record ->
-                    StudyRecordItem(record = record, isStudyFeed = isStudyFeed, onClick = onClick)
+                    StudyRecordItem(
+                        record = record,
+                        isStudyFeed = isStudyFeed,
+                        isSelectedMode = isSelectedMode,
+                        isDeleteSelected = record.id in deleteSelectedRecordIds,
+                        onClick = onClick,
+                        onDeleteSelect = onDeleteSelect,
+                    )
                 }
             }
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordList.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/studyrecord/StudyRecordList.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.ScrollableDefaults
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -80,6 +81,7 @@ fun StudyRecordList(
                     .fillMaxSize()
                     .overscroll(overscrollEffect),
             state = listState,
+            contentPadding = PaddingValues(vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             groupedRecords.forEach { (date, recordsForDate) ->

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalByDateScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalByDateScreen.kt
@@ -40,6 +40,10 @@ fun PersonalByDateScreen(
     hasDateDataNext: Boolean,
     // study point
     studiedDates: ImmutableSet<LocalDate>,
+    // delete selected
+    isSelectedMode: Boolean = false,
+    deleteSelectedRecordIds: Set<Long> = setOf(),
+    onDeleteSelect: (Long) -> Unit = {},
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         DatePicker(
@@ -78,6 +82,9 @@ fun PersonalByDateScreen(
                 onClick = navigateToEditScreen,
                 onLoadMore = onLoadMore,
                 hasNext = hasDateDataNext,
+                isSelectedMode = isSelectedMode,
+                deleteSelectedRecordIds = deleteSelectedRecordIds,
+                onDeleteSelect = onDeleteSelect,
             )
         }
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalByTagScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalByTagScreen.kt
@@ -26,6 +26,10 @@ fun PersonalByTagScreen(
     // Paging
     onLoadMore: () -> Unit,
     hasTagDataNext: Boolean,
+    // delete selected
+    isSelectedMode: Boolean = false,
+    deleteSelectedRecordIds: Set<Long> = setOf(),
+    onDeleteSelect: (Long) -> Unit = {},
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         TagList(
@@ -44,6 +48,9 @@ fun PersonalByTagScreen(
             onClick = navigateToEditScreen,
             onLoadMore = onLoadMore,
             hasNext = hasTagDataNext,
+            isSelectedMode = isSelectedMode,
+            deleteSelectedRecordIds = deleteSelectedRecordIds,
+            onDeleteSelect = onDeleteSelect,
         )
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalContract.kt
@@ -49,6 +49,21 @@ class PersonalContract {
 
         data object OnRecordRefresh : Event()
 
+        // Delete selected
+        data class OnDeleteSelecte(
+            val recordId: Long,
+        ) : Event()
+
+        data object OnSelectModeChange : Event()
+
+        data object OnSelectCancel : Event()
+
+        data object OnSelectDelete : Event()
+
+        data object OnSelectDialogConfirm : Event()
+
+        data object OnSelectDialogCancel : Event()
+
         // Date
         data class OnDateSelected(
             val date: String,
@@ -82,6 +97,10 @@ class PersonalContract {
         val hasDateDataNext: Boolean = false,
         val dateCursorId: Long? = null,
         val dateCursorCreatedAt: String? = null,
+        // delete selected
+        val isSelectedMode: Boolean = false,
+        val deleteSelectedRecordIds: Set<Long> = emptySet(),
+        val isDeleteDialogShow: Boolean = false,
     ) : UiState
 
     sealed class Effect : UiEffect {

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalContract.kt
@@ -50,7 +50,7 @@ class PersonalContract {
         data object OnRecordRefresh : Event()
 
         // Delete selected
-        data class OnDeleteSelecte(
+        data class OnDeleteSelect(
             val recordId: Long,
         ) : Event()
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalScreen.kt
@@ -204,7 +204,7 @@ fun PersonalScreen(
         modifier =
             modifier
                 .fillMaxSize()
-                .padding(start = 8.dp, end = 8.dp, bottom = 16.dp),
+                .padding(start = 8.dp, end = 8.dp),
     ) {
         TabRow(
             modifier = Modifier.background(NeeGongNaeGongTheme.colorScheme.background),

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalScreen.kt
@@ -246,9 +246,9 @@ fun PersonalScreen(
         PersonalTopAppBar(
             isSelectedMode = isSelectedMode,
             deleteSelectedRecordIds = deleteSelectedRecordIds,
-            onModeChange = { onSelectModeChange() },
-            onCancel = { onSelectCancel() },
-            onDelete = { onSelectDelete() },
+            onModeChange = onSelectModeChange,
+            onCancel = onSelectCancel,
+            onDelete = onSelectDelete,
         )
 
         TabRow(

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalScreen.kt
@@ -38,6 +38,8 @@ import com.ssafy.neegongnaegong.domain.model.learning.Tag
 import com.ssafy.neegongnaegong.domain.model.preview.personal.PersonalPreviewDataProvider
 import com.ssafy.neegongnaegong.presentation.component.LoadingDialog
 import com.ssafy.neegongnaegong.presentation.component.picker.date.rememberDatePickerState
+import com.ssafy.neegongnaegong.presentation.personal.component.DeleteSelectedLearningRecordsDialog
+import com.ssafy.neegongnaegong.presentation.personal.component.PersonalTopAppBar
 import com.ssafy.neegongnaegong.presentation.timer.component.write.TagSelectDialog
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
@@ -96,6 +98,12 @@ fun PersonalRoute(
         onDateSelected = { viewModel.setEvent(PersonalContract.Event.OnDateSelected(it)) },
         navigateToEditScreen = navigateToEditScreen,
         onLoadMore = { viewModel.setEvent(PersonalContract.Event.OnRecordLoadMore) },
+        onDeleteSelect = { viewModel.setEvent(PersonalContract.Event.OnDeleteSelecte(it)) },
+        onSelectModeChange = { viewModel.setEvent(PersonalContract.Event.OnSelectModeChange) },
+        onSelectCancel = { viewModel.setEvent(PersonalContract.Event.OnSelectCancel) },
+        onSelectDelete = { viewModel.setEvent(PersonalContract.Event.OnSelectDelete) },
+        onSelectDialogConfirm = { viewModel.setEvent(PersonalContract.Event.OnSelectDialogConfirm) },
+        onSelectDialogCancel = { viewModel.setEvent(PersonalContract.Event.OnSelectDialogCancel) },
     )
 }
 
@@ -119,6 +127,13 @@ fun PersonalContent(
     navigateToEditScreen: (Long) -> Unit,
     // paging
     onLoadMore: () -> Unit,
+    // delete selected
+    onDeleteSelect: (Long) -> Unit,
+    onSelectModeChange: () -> Unit,
+    onSelectCancel: () -> Unit,
+    onSelectDelete: () -> Unit,
+    onSelectDialogConfirm: () -> Unit,
+    onSelectDialogCancel: () -> Unit,
 ) {
     val context = LocalContext.current
 
@@ -131,6 +146,14 @@ fun PersonalContent(
             onSearchQueryChanged = onSearchQueryChanged,
             onTagSelected = onTagSelected,
             onTagDeselected = onTagDeselected,
+        )
+    }
+
+    if (uiState.isDeleteDialogShow) {
+        DeleteSelectedLearningRecordsDialog(
+            selectedCount = uiState.deleteSelectedRecordIds.size,
+            onConfirm = onSelectDialogConfirm,
+            onCancel = onSelectDialogCancel,
         )
     }
 
@@ -167,6 +190,13 @@ fun PersonalContent(
         hasTagDataNext = uiState.hasTagDataNext,
         hasDateDataNext = uiState.hasDateDataNext,
         studiedDates = uiState.learningDates,
+        // delete selected
+        isSelectedMode = uiState.isSelectedMode,
+        deleteSelectedRecordIds = uiState.deleteSelectedRecordIds,
+        onDeleteSelect = onDeleteSelect,
+        onSelectModeChange = onSelectModeChange,
+        onSelectCancel = onSelectCancel,
+        onSelectDelete = onSelectDelete,
     )
 
     if (uiState.isLoading) {
@@ -194,6 +224,13 @@ fun PersonalScreen(
     hasDateDataNext: Boolean,
     // study point
     studiedDates: ImmutableSet<LocalDate>,
+    // delete selected
+    isSelectedMode: Boolean = false,
+    deleteSelectedRecordIds: Set<Long> = setOf(),
+    onDeleteSelect: (Long) -> Unit = {},
+    onSelectModeChange: () -> Unit = {},
+    onSelectCancel: () -> Unit = {},
+    onSelectDelete: () -> Unit = {},
 ) {
     val tabTitles = listOf("태그별", "날짜별")
     val pagerState = rememberPagerState(pageCount = { tabTitles.size })
@@ -206,6 +243,14 @@ fun PersonalScreen(
                 .fillMaxSize()
                 .padding(start = 8.dp, end = 8.dp),
     ) {
+        PersonalTopAppBar(
+            isSelectedMode = isSelectedMode,
+            deleteSelectedRecordIds = deleteSelectedRecordIds,
+            onModeChange = { onSelectModeChange() },
+            onCancel = { onSelectCancel() },
+            onDelete = { onSelectDelete() },
+        )
+
         TabRow(
             modifier = Modifier.background(NeeGongNaeGongTheme.colorScheme.background),
             selectedTabIndex = pagerState.currentPage,
@@ -271,6 +316,9 @@ fun PersonalScreen(
                         navigateToEditScreen = navigateToEditScreen,
                         onLoadMore = onLoadMore,
                         hasTagDataNext = hasTagDataNext,
+                        isSelectedMode = isSelectedMode,
+                        deleteSelectedRecordIds = deleteSelectedRecordIds,
+                        onDeleteSelect = onDeleteSelect,
                     )
                 }
 
@@ -285,6 +333,9 @@ fun PersonalScreen(
                         onLoadMore = onLoadMore,
                         hasDateDataNext = hasDateDataNext,
                         studiedDates = studiedDates,
+                        isSelectedMode = isSelectedMode,
+                        deleteSelectedRecordIds = deleteSelectedRecordIds,
+                        onDeleteSelect = onDeleteSelect,
                     )
                 }
             }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalScreen.kt
@@ -98,7 +98,7 @@ fun PersonalRoute(
         onDateSelected = { viewModel.setEvent(PersonalContract.Event.OnDateSelected(it)) },
         navigateToEditScreen = navigateToEditScreen,
         onLoadMore = { viewModel.setEvent(PersonalContract.Event.OnRecordLoadMore) },
-        onDeleteSelect = { viewModel.setEvent(PersonalContract.Event.OnDeleteSelecte(it)) },
+        onDeleteSelect = { viewModel.setEvent(PersonalContract.Event.OnDeleteSelect(it)) },
         onSelectModeChange = { viewModel.setEvent(PersonalContract.Event.OnSelectModeChange) },
         onSelectCancel = { viewModel.setEvent(PersonalContract.Event.OnSelectCancel) },
         onSelectDelete = { viewModel.setEvent(PersonalContract.Event.OnSelectDelete) },

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalViewModel.kt
@@ -406,20 +406,19 @@ class PersonalViewModel
         private fun deleteRecords() {
             val deleteSelectedRecordIdsList = uiState.value.deleteSelectedRecordIds.toList()
             viewModelScope.launch {
-                deleteSelectedLearningRecordsUseCase
-                    .invoke(
-                        recordIds = deleteSelectedRecordIdsList,
-                    ).withLoading {
-                        setState { copy(isLoading = it) }
-                    }.safeCollect {
-                        setState { copy(deleteSelectedRecordIds = emptySet()) }
-                        setState { copy(isSelectedMode = false) }
-                        showMessage(
-                            message = "선택된 기록을 삭제했습니다.",
-                            type = SnackbarManager.Type.Success,
-                        )
-                        loadLearningRecords()
-                    }
+                deleteSelectedLearningRecordsUseCase(
+                    recordIds = deleteSelectedRecordIdsList,
+                ).withLoading {
+                    setState { copy(isLoading = it) }
+                }.safeCollect {
+                    setState { copy(deleteSelectedRecordIds = emptySet()) }
+                    setState { copy(isSelectedMode = false) }
+                    showMessage(
+                        message = "선택된 기록을 삭제했습니다.",
+                        type = SnackbarManager.Type.Success,
+                    )
+                    loadLearningRecords()
+                }
             }
         }
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalViewModel.kt
@@ -113,7 +113,7 @@ class PersonalViewModel
                     loadLearningRecords()
                 }
 
-                is PersonalContract.Event.OnDeleteSelecte -> {
+                is PersonalContract.Event.OnDeleteSelect -> {
                     deleteSelectedRecord(event.recordId)
                 }
 

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/PersonalViewModel.kt
@@ -4,10 +4,12 @@ import androidx.lifecycle.viewModelScope
 import com.ssafy.neegongnaegong.data.mapper.learningrecord.LearningRecordMapper.toDomain
 import com.ssafy.neegongnaegong.domain.data.TagData
 import com.ssafy.neegongnaegong.domain.model.learning.Tag
+import com.ssafy.neegongnaegong.domain.usecase.learningrecord.DeleteSelectedLearningRecordsUseCase
 import com.ssafy.neegongnaegong.domain.usecase.learningrecord.GetLearningRecordDatesByMonthUseCase
 import com.ssafy.neegongnaegong.domain.usecase.learningrecord.GetLearningRecordListUseCase
 import com.ssafy.neegongnaegong.presentation.base.BaseViewModel
 import com.ssafy.neegongnaegong.presentation.timer.learning.LearningRecordWriteViewModel.Companion.MAX_TAG_LIMIT
+import com.ssafy.neegongnaegong.presentation.util.SnackbarManager
 import com.ssafy.neegongnaegong.presentation.util.toYearMonthTriple
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -25,6 +27,7 @@ class PersonalViewModel
     constructor(
         private val getLearningRecordListUseCase: GetLearningRecordListUseCase,
         private val getLearningRecordDatesByMonthUseCase: GetLearningRecordDatesByMonthUseCase,
+        private val deleteSelectedLearningRecordsUseCase: DeleteSelectedLearningRecordsUseCase,
     ) : BaseViewModel<PersonalContract.Event, PersonalContract.State, PersonalContract.Effect>() {
         override fun createInitialState(): PersonalContract.State = PersonalContract.State().copy(selectedDate = LocalDate.now().toString())
 
@@ -108,6 +111,31 @@ class PersonalViewModel
 
                 is PersonalContract.Event.OnRecordRefresh -> {
                     loadLearningRecords()
+                }
+
+                is PersonalContract.Event.OnDeleteSelecte -> {
+                    deleteSelectedRecord(event.recordId)
+                }
+
+                is PersonalContract.Event.OnSelectModeChange -> {
+                    setState { copy(isSelectedMode = isSelectedMode.not()) }
+                }
+
+                is PersonalContract.Event.OnSelectCancel -> {
+                    setState { copy(deleteSelectedRecordIds = emptySet()) }
+                }
+
+                is PersonalContract.Event.OnSelectDelete -> {
+                    setState { copy(isDeleteDialogShow = true) }
+                }
+
+                is PersonalContract.Event.OnSelectDialogCancel -> {
+                    setState { copy(isDeleteDialogShow = false) }
+                }
+
+                is PersonalContract.Event.OnSelectDialogConfirm -> {
+                    deleteRecords()
+                    setState { copy(isDeleteDialogShow = false) }
                 }
             }
         }
@@ -363,5 +391,35 @@ class PersonalViewModel
                 }
             }
             return pi
+        }
+
+        private fun deleteSelectedRecord(recordId: Long) {
+            val currentSelectedRecordIds = uiState.value.deleteSelectedRecordIds.toMutableSet()
+            if (currentSelectedRecordIds.contains(recordId)) {
+                currentSelectedRecordIds.remove(recordId)
+            } else {
+                currentSelectedRecordIds.add(recordId)
+            }
+            setState { copy(deleteSelectedRecordIds = currentSelectedRecordIds) }
+        }
+
+        private fun deleteRecords() {
+            val deleteSelectedRecordIdsList = uiState.value.deleteSelectedRecordIds.toList()
+            viewModelScope.launch {
+                deleteSelectedLearningRecordsUseCase
+                    .invoke(
+                        recordIds = deleteSelectedRecordIdsList,
+                    ).withLoading {
+                        setState { copy(isLoading = it) }
+                    }.safeCollect {
+                        setState { copy(deleteSelectedRecordIds = emptySet()) }
+                        setState { copy(isSelectedMode = false) }
+                        showMessage(
+                            message = "선택된 기록을 삭제했습니다.",
+                            type = SnackbarManager.Type.Success,
+                        )
+                        loadLearningRecords()
+                    }
+            }
         }
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/component/DeleteSelectedLearningRecordsDialog.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/component/DeleteSelectedLearningRecordsDialog.kt
@@ -1,0 +1,153 @@
+package com.ssafy.neegongnaegong.presentation.personal.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
+
+@Composable
+fun DeleteSelectedLearningRecordsDialog(
+    modifier: Modifier = Modifier,
+    selectedCount: Int,
+    onCancel: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val keywordStyle =
+        SpanStyle(
+            color = NeeGongNaeGongTheme.colorScheme.primaryText,
+            fontSize = NeeGongNaeGongTheme.typography.bodyMedium.fontSize,
+            fontStyle = NeeGongNaeGongTheme.typography.bodyMedium.fontStyle,
+            fontWeight = NeeGongNaeGongTheme.typography.bodyMedium.fontWeight,
+            letterSpacing = NeeGongNaeGongTheme.typography.bodyMedium.letterSpacing,
+        )
+    val defaultStyle =
+        SpanStyle(
+            color = NeeGongNaeGongTheme.colorScheme.secondaryText,
+            fontSize = NeeGongNaeGongTheme.typography.bodyMedium.fontSize,
+            fontStyle = NeeGongNaeGongTheme.typography.labelMedium.fontStyle,
+            fontWeight = NeeGongNaeGongTheme.typography.labelMedium.fontWeight,
+            letterSpacing = NeeGongNaeGongTheme.typography.labelMedium.letterSpacing,
+        )
+
+    Dialog(onDismissRequest = { onCancel.invoke() }) {
+        Box(
+            modifier =
+                modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = NeeGongNaeGongTheme.colorScheme.background,
+                        shape = RoundedCornerShape(12.dp),
+                    ),
+        ) {
+            Column(
+                modifier = Modifier.padding(top = 20.dp, start = 10.dp, end = 10.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = "개인기록 삭제",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Text(
+                    text =
+                        buildAnnotatedString {
+                            withStyle(style = defaultStyle) {
+                                append("선택된 ")
+                            }
+                            withStyle(style = keywordStyle) {
+                                append("$selectedCount")
+                            }
+                            withStyle(style = defaultStyle) {
+                                append("개 기록을 삭제합니다.")
+                            }
+                        },
+                    textAlign = TextAlign.Center,
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                HorizontalDivider(thickness = 0.4.dp, color = Color.Gray)
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    TextButton(
+                        onClick = onCancel,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text(
+                            text = "취소",
+                            style = NeeGongNaeGongTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = NeeGongNaeGongTheme.colorScheme.secondaryText,
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    VerticalDivider(
+                        thickness = 0.4.dp,
+                        color = Color.Gray,
+                        modifier = Modifier.height(50.dp),
+                    )
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    TextButton(
+                        onClick = onConfirm,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text(
+                            text = "삭제",
+                            style = NeeGongNaeGongTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = NeeGongNaeGongTheme.colorScheme.peach,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@NeeGongNaeGongPreviews
+@Composable
+private fun PreviewDeleteSelectedLearningRecordsDialog() {
+    NeeGongNaeGongTheme {
+        DeleteSelectedLearningRecordsDialog(
+            selectedCount = 5,
+            onCancel = {},
+            onConfirm = {},
+        )
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/component/PersonalTopAppBar.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/personal/component/PersonalTopAppBar.kt
@@ -1,0 +1,138 @@
+package com.ssafy.neegongnaegong.presentation.personal.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ssafy.neegongnaegong.R
+import com.ssafy.neegongnaegong.presentation.component.TopAppBar
+import com.ssafy.neegongnaegong.presentation.component.TopAppBarNavigationType
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
+import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
+import com.ssafy.neegongnaegong.presentation.util.noRippleClickable
+
+@Composable
+fun PersonalTopAppBar(
+    isSelectedMode: Boolean,
+    deleteSelectedRecordIds: Set<Long>,
+    onModeChange: () -> Unit = {},
+    onCancel: () -> Unit = {},
+    onDelete: () -> Unit = {},
+) {
+    val keywordStyle =
+        SpanStyle(
+            color = NeeGongNaeGongTheme.colorScheme.primaryText,
+            fontSize = NeeGongNaeGongTheme.typography.bodyMedium.fontSize,
+            fontStyle = NeeGongNaeGongTheme.typography.bodyMedium.fontStyle,
+            fontWeight = NeeGongNaeGongTheme.typography.bodyMedium.fontWeight,
+            letterSpacing = NeeGongNaeGongTheme.typography.bodyMedium.letterSpacing,
+        )
+    val defaultStyle =
+        SpanStyle(
+            color = NeeGongNaeGongTheme.colorScheme.primaryText,
+            fontSize = NeeGongNaeGongTheme.typography.bodyMedium.fontSize,
+            fontStyle = NeeGongNaeGongTheme.typography.labelMedium.fontStyle,
+            fontWeight = NeeGongNaeGongTheme.typography.labelMedium.fontWeight,
+            letterSpacing = NeeGongNaeGongTheme.typography.labelMedium.letterSpacing,
+        )
+
+    TopAppBar(
+        modifier = Modifier.defaultMinSize(minHeight = 32.dp),
+        navigationType = TopAppBarNavigationType.None,
+        title = {
+            Text(
+                text =
+                    if (isSelectedMode) {
+                        buildAnnotatedString {
+                            withStyle(style = keywordStyle) {
+                                append("${deleteSelectedRecordIds.size}")
+                            }
+                            withStyle(style = defaultStyle) {
+                                append("개 선택")
+                            }
+                        }
+                    } else {
+                        buildAnnotatedString {
+                            withStyle(style = keywordStyle) {
+                                append("내 기록")
+                            }
+                        }
+                    },
+            )
+        },
+        actionButtons = {
+            if (isSelectedMode) {
+                Row(
+                    modifier = Modifier,
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        modifier =
+                            Modifier.noRippleClickable {
+                                onCancel()
+                                onModeChange()
+                            },
+                        text = "취소",
+                        style = NeeGongNaeGongTheme.typography.bodySmall.copy(fontSize = 16.sp),
+                        color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                    )
+                    Text(
+                        modifier =
+                            Modifier.noRippleClickable {
+                                onDelete()
+                            },
+                        text = "삭제",
+                        style = NeeGongNaeGongTheme.typography.bodySmall.copy(fontSize = 16.sp),
+                        color = NeeGongNaeGongTheme.colorScheme.primaryText,
+                    )
+                }
+            } else {
+                Icon(
+                    modifier =
+                        Modifier
+                            .size(28.dp)
+                            .padding(end = 4.dp)
+                            .noRippleClickable { onModeChange() },
+                    painter = painterResource(R.drawable.ic_common_trash),
+                    contentDescription = "기록 삭제",
+                    tint = NeeGongNaeGongTheme.colorScheme.primaryText,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+@NeeGongNaeGongPreviews
+private fun PreviewPersonalTopAppBarFalse() {
+    NeeGongNaeGongTheme {
+        PersonalTopAppBar(
+            isSelectedMode = false,
+            deleteSelectedRecordIds = emptySet(),
+        )
+    }
+}
+
+@Composable
+@NeeGongNaeGongPreviews
+private fun PreviewPersonalTopAppBarTrue() {
+    NeeGongNaeGongTheme {
+        PersonalTopAppBar(
+            isSelectedMode = true,
+            deleteSelectedRecordIds = emptySet(),
+        )
+    }
+}


### PR DESCRIPTION
## 📌 연결된 이슈
- #211

### ✅ 작업 내용
- 공부기록 다건 삭제 **API** 구현
- **선택**하여 삭제 기능 구현
- 삭제 전 확인 **다이어로그** 구현

### 📷 관련 이미지(영상)
- 체크박스로도 가능하지만 기존 **componet** 요소들을 클릭해서 선택가능
- 선택된 항목들에 대해서는 투명도 설정하여 시각적으로 구분 처리
<img src="https://github.com/user-attachments/assets/29efaf05-4c6a-4c78-a214-b4868213a80c" width="300">


### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
현재 날짜별 화면에서는 공부기록을 지워 그 해당 날짜에 공부기록이 사라져도 달력에 빨간 점 표기가 사라지지 않는 현상을 인지했습니다.
앱을 다시 재실행하면 표기가 정상적으로 동작은 하는데, 삭제 로직은 태그별 화면에서 진행을 많이할 거 같아 이슈를 생성하고 후순위로 진행해보겠습니다.

@Na2te 
close #211 