### PR TITLE
스터디 관련 조회 커서 response값 수정

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSource.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSource.kt
@@ -13,7 +13,6 @@ import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupNoticeListRequ
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupVoteListRequest
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyMemberInfo
 import kotlinx.coroutines.flow.Flow
-import java.time.LocalDateTime
 
 interface NetworkStudyGroupDataSource {
     fun getMemberStudyLogsByTag(request: StudyMemberInfo): Flow<List<StudyLogByTagResponse>>
@@ -68,7 +67,7 @@ interface NetworkStudyGroupDataSource {
     fun getStudyGroupDetail(studyGroupId: Long): Flow<StudyGroupDetailResponse>
 
     fun getMyStudyGroupList(
-        cursorCreatedAt: LocalDateTime?,
+        cursorCreatedAt: String?,
         cursorId: Long?,
         size: Int,
     ): Flow<MyStudyGroupListResponse>

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSourceImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSourceImpl.kt
@@ -17,7 +17,6 @@ import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupNoticeListRequ
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyGroupVoteListRequest
 import com.ssafy.neegongnaegong.domain.model.studygroup.StudyMemberInfo
 import kotlinx.coroutines.flow.Flow
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 class NetworkStudyGroupDataSourceImpl
@@ -148,7 +147,7 @@ class NetworkStudyGroupDataSourceImpl
             }
 
         override fun getMyStudyGroupList(
-            cursorCreatedAt: LocalDateTime?,
+            cursorCreatedAt: String?,
             cursorId: Long?,
             size: Int,
         ): Flow<MyStudyGroupListResponse> =

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/cursor/CursorMapper.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/cursor/CursorMapper.kt
@@ -1,0 +1,13 @@
+package com.ssafy.neegongnaegong.data.mapper.cursor
+
+import com.ssafy.neegongnaegong.data.model.cursor.NextCursorData
+import com.ssafy.neegongnaegong.domain.model.cursor.NextCursorDomain
+
+internal object CursorMapper {
+    fun NextCursorData.toDomain() =
+        NextCursorDomain(
+            cursorValue = cursorValue,
+            cursorId = cursorId,
+            first = first,
+        )
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/studies/StudiesMapper.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/mapper/studies/StudiesMapper.kt
@@ -1,0 +1,14 @@
+package com.ssafy.neegongnaegong.data.mapper.studies
+
+import com.ssafy.neegongnaegong.data.mapper.cursor.CursorMapper.toDomain
+import com.ssafy.neegongnaegong.data.model.studies.response.CursorSliceStudiesListResponse
+import com.ssafy.neegongnaegong.domain.model.studies.CursorStudiesPage
+
+internal object StudiesMapper {
+    fun CursorSliceStudiesListResponse.toDomain() =
+        CursorStudiesPage(
+            content = content.map { it.toDomain() },
+            hasNext = hasNext,
+            nextCursor = nextCursor.toDomain(),
+        )
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/cursor/NextCursorData.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/cursor/NextCursorData.kt
@@ -1,0 +1,7 @@
+package com.ssafy.neegongnaegong.data.model.cursor
+
+data class NextCursorData(
+    val cursorValue: String,
+    val cursorId: Long,
+    val first: Boolean,
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/studies/response/CursorSliceStudiesListResponse.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/studies/response/CursorSliceStudiesListResponse.kt
@@ -1,18 +1,9 @@
 package com.ssafy.neegongnaegong.data.model.studies.response
 
-import com.ssafy.neegongnaegong.domain.model.studies.CursorStudiesPage
+import com.ssafy.neegongnaegong.data.model.cursor.NextCursorData
 
 data class CursorSliceStudiesListResponse(
     val content: List<StudiesResponse>,
     val hasNext: Boolean,
-    val cursorCreatedAt: String,
-    val cursorId: Long,
-) {
-    fun toDomain(): CursorStudiesPage =
-        CursorStudiesPage(
-            content = content.map { it.toDomain() },
-            hasNext = hasNext,
-            cursorCreatedAt = cursorCreatedAt,
-            cursorId = cursorId,
-        )
-}
+    val nextCursor: NextCursorData,
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/studygroup/response/MyStudyGroupListResponse.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/studygroup/response/MyStudyGroupListResponse.kt
@@ -1,13 +1,13 @@
 package com.ssafy.neegongnaegong.data.model.studygroup.response
 
+import com.ssafy.neegongnaegong.data.model.cursor.NextCursorData
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class MyStudyGroupListResponse(
     val content: List<MyStudyGroupResponse>,
     val hasNext: Boolean,
-    val cursorCreatedAt: LocalDateTime,
-    val cursorId: Long,
+    val nextCursor: NextCursorData,
 ) {
     data class MyStudyGroupResponse(
         val id: Long,

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/paging/MyStudyGroupListPagingSource.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/paging/MyStudyGroupListPagingSource.kt
@@ -4,16 +4,15 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.ssafy.neegongnaegong.data.datasource.network.NetworkStudyGroupDataSource
 import com.ssafy.neegongnaegong.data.mapper.studygroup.MyStudyGroupListMapper.toDomain
-import com.ssafy.neegongnaegong.data.mapper.studygroup.StudyGroupVoteHistoryInfoMapper.toDomain
 import com.ssafy.neegongnaegong.data.model.studygroup.response.MyStudyGroupListResponse
-import com.ssafy.neegongnaegong.domain.model.studygroup.CursorSliceKey
+import com.ssafy.neegongnaegong.domain.model.studygroup.MyStudyGroupCursorSliceKey
 import com.ssafy.neegongnaegong.domain.model.studygroup.MyStudyGroupInfo
 import kotlinx.coroutines.flow.first
 
 class MyStudyGroupListPagingSource(
     private val dataSource: NetworkStudyGroupDataSource,
-) : PagingSource<CursorSliceKey, MyStudyGroupInfo>() {
-    override suspend fun load(params: LoadParams<CursorSliceKey>): LoadResult<CursorSliceKey, MyStudyGroupInfo> {
+) : PagingSource<MyStudyGroupCursorSliceKey, MyStudyGroupInfo>() {
+    override suspend fun load(params: LoadParams<MyStudyGroupCursorSliceKey>): LoadResult<MyStudyGroupCursorSliceKey, MyStudyGroupInfo> {
         return try {
             val cursor = params.key
 
@@ -32,7 +31,7 @@ class MyStudyGroupListPagingSource(
                 prevKey = null,
                 nextKey =
                     if (response.hasNext) {
-                        CursorSliceKey(response.cursorCreatedAt, response.cursorId)
+                        MyStudyGroupCursorSliceKey(response.nextCursor.cursorValue, response.nextCursor.cursorId)
                     } else {
                         null
                     },
@@ -42,9 +41,9 @@ class MyStudyGroupListPagingSource(
         }
     }
 
-    override fun getRefreshKey(state: PagingState<CursorSliceKey, MyStudyGroupInfo>): CursorSliceKey? {
+    override fun getRefreshKey(state: PagingState<MyStudyGroupCursorSliceKey, MyStudyGroupInfo>): MyStudyGroupCursorSliceKey? {
         return state.firstItemOrNull()?.let {
-            CursorSliceKey(it.cursorCreatedAt, it.cursorId)
+            MyStudyGroupCursorSliceKey(it.cursorCreatedAt.toString(), it.cursorId)
         }
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
@@ -112,7 +112,7 @@ interface StudyGroupApi {
 
     @GET("$PREFIX/my/list")
     suspend fun getMyStudyGroupList(
-        @Query("cursor-value") cursorCreatedAt: LocalDateTime?,
+        @Query("cursor-value") cursorCreatedAt: String?,
         @Query("cursor-id") cursorId: Long?,
         @Query("size") size: Int,
     ): Result<ApiResponse<MyStudyGroupListResponse>>

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/repository/StudiesRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/repository/StudiesRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.ssafy.neegongnaegong.data.datasource.network.NetworkStudiesDataSource
 import com.ssafy.neegongnaegong.data.mapper.studies.StudiesApplicationsMapper.toDomain
 import com.ssafy.neegongnaegong.data.mapper.studies.StudiesContentsMapper.toDomain
 import com.ssafy.neegongnaegong.data.mapper.studies.StudiesFeedsMapper.toDomain
+import com.ssafy.neegongnaegong.data.mapper.studies.StudiesMapper.toDomain
 import com.ssafy.neegongnaegong.data.mapper.studies.StudiesMemberMapper.toDomain
 import com.ssafy.neegongnaegong.data.mapper.studies.StudiesWeeklyRankingsMapper.toDomain
 import com.ssafy.neegongnaegong.data.mapper.vote.VoteMapper.toCreateRequest
@@ -74,9 +75,8 @@ class StudiesRepositoryImpl
                     ).map { slice ->
                         CursorSliceStudiesListResponse(
                             content = slice.content,
-                            cursorCreatedAt = slice.cursorCreatedAt,
                             hasNext = slice.hasNext,
-                            cursorId = slice.cursorId,
+                            nextCursor = slice.nextCursor,
                         ).toDomain()
                     }
             }

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/cursor/NextCursorDomain.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/cursor/NextCursorDomain.kt
@@ -1,0 +1,7 @@
+package com.ssafy.neegongnaegong.domain.model.cursor
+
+data class NextCursorDomain(
+    val cursorValue: String,
+    val cursorId: Long,
+    val first: Boolean,
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studies/CursorStudiesPage.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studies/CursorStudiesPage.kt
@@ -1,8 +1,9 @@
 package com.ssafy.neegongnaegong.domain.model.studies
 
+import com.ssafy.neegongnaegong.domain.model.cursor.NextCursorDomain
+
 data class CursorStudiesPage(
     val content: List<Studies>,
     val hasNext: Boolean,
-    val cursorCreatedAt: String,
-    val cursorId: Long,
+    val nextCursor: NextCursorDomain,
 )

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/MyStudyGroupCursorSliceKey.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/model/studygroup/MyStudyGroupCursorSliceKey.kt
@@ -1,0 +1,6 @@
+package com.ssafy.neegongnaegong.domain.model.studygroup
+
+data class MyStudyGroupCursorSliceKey(
+    val cursorCreatedAt: String,
+    val cursorId: Long,
+)

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/find/StudiesFindContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/find/StudiesFindContract.kt
@@ -38,7 +38,7 @@ class StudiesFindContract {
         val isLoading: Boolean = false,
         val studiesList: List<Studies> = emptyList(),
         val hasNext: Boolean = true,
-        val cursorCreateAt: String? = null,
+        val cursorValue: String? = null,
         val cursorId: Long? = null,
         // 선택한 스터디 및 다이어로그 상태
         val selectedStudies: Studies? = null,

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/find/StudiesFindViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/find/StudiesFindViewModel.kt
@@ -83,7 +83,7 @@ class StudiesFindViewModel
 
             viewModelScope.launch {
                 getStudiesListUseCase(
-                    cursorCreatedAt = uiState.value.cursorCreateAt,
+                    cursorCreatedAt = uiState.value.cursorValue,
                     cursorId = uiState.value.cursorId,
                 ).withLoading {
                     setState { copy(isLoading = it) }
@@ -96,8 +96,8 @@ class StudiesFindViewModel
                     setState {
                         copy(
                             hasNext = result.hasNext,
-                            cursorCreateAt = result.cursorCreatedAt,
-                            cursorId = result.cursorId,
+                            cursorValue = result.nextCursor.cursorValue,
+                            cursorId = result.nextCursor.cursorId,
                         )
                     }
                 }


### PR DESCRIPTION
## 📌 연결된 이슈
- #216

### ✅ 작업 내용
- 스터디 전체 목록 조회 reponse 수정
- 내 스터디 목록 조회 reponse 수정

### 📷 관련 이미지(영상)

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
기존 `CursorSliceKey` model을 다른 곳에도 공통으로 사용됨에 따라, `MyStudyGroupCursorSliceKey`로 구분지어 작성했습니다.
추후, 커서를 활용하는 곳들도 수정작업이 필요해 보입니다.

변수명은 **cursorCratedAt**으로 변경을 하지 않았는데, 이 이유는 스터디 검색 및, 필터를 적용할 때 통일된 변수명으로 작업할 예정입니다.
현재로는 `cursorValue`로 생각중입니다.
우선 빠른 수정을 위해 **타입**만 변경했다는걸 말씀드리고 싶습니다!🫠
@Na2te 
close #216