### PR TITLE
그룹 탈퇴 API 연동

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSource.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSource.kt
@@ -72,4 +72,6 @@ interface NetworkStudyGroupDataSource {
         cursorId: Long?,
         size: Int,
     ): Flow<MyStudyGroupListResponse>
+
+    fun leaveStudyGroup(studyGroupId: Long): Flow<Unit>
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSourceImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/datasource/network/NetworkStudyGroupDataSourceImpl.kt
@@ -159,4 +159,9 @@ class NetworkStudyGroupDataSourceImpl
                     size = size,
                 )
             }
+
+        override fun leaveStudyGroup(studyGroupId: Long): Flow<Unit> =
+            apiFlow {
+                api.leaveStudyGroup(studyGroupId)
+            }
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
@@ -117,6 +117,11 @@ interface StudyGroupApi {
         @Query("size") size: Int,
     ): Result<ApiResponse<MyStudyGroupListResponse>>
 
+    @DELETE("$PREFIX/{study-group-id}/withdrawal")
+    suspend fun leaveStudyGroup(
+        @Query("study-group-id")studyGroupId: Long,
+    ): Result<ApiResponse<Unit>>
+
     companion object {
         private const val PREFIX = "/api/study-groups"
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/remote/StudyGroupApi.kt
@@ -119,7 +119,7 @@ interface StudyGroupApi {
 
     @DELETE("$PREFIX/{study-group-id}/withdrawal")
     suspend fun leaveStudyGroup(
-        @Query("study-group-id")studyGroupId: Long,
+        @Path("study-group-id") studyGroupId: Long,
     ): Result<ApiResponse<Unit>>
 
     companion object {

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/repository/StudyGroupRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/repository/StudyGroupRepositoryImpl.kt
@@ -146,4 +146,6 @@ class StudyGroupRepositoryImpl
                     )
                 },
             ).flow.flowOn(ioDispatcher)
+
+        override fun leaveStudyGroup(studyGroupId: Long): Flow<Unit> = dataSource.leaveStudyGroup(studyGroupId)
     }

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/StudyGroupRepository.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/repository/StudyGroupRepository.kt
@@ -65,4 +65,6 @@ interface StudyGroupRepository {
     fun getStudyGroupDetail(studyGroupId: Long): Flow<StudyGroupDetailInfo>
 
     fun getMyStudyGroupList(size: Int): Flow<PagingData<MyStudyGroupInfo>>
+
+    fun leaveStudyGroup(studyGroupId: Long): Flow<Unit>
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/studygroup/LeaveStudyGroupUseCase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/domain/usecase/studygroup/LeaveStudyGroupUseCase.kt
@@ -1,0 +1,13 @@
+package com.ssafy.neegongnaegong.domain.usecase.studygroup
+
+import com.ssafy.neegongnaegong.domain.repository.StudyGroupRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class LeaveStudyGroupUseCase
+    @Inject
+    constructor(
+        private val repository: StudyGroupRepository,
+    ) {
+        operator fun invoke(studyGroupId: Long): Flow<Unit> = repository.leaveStudyGroup(studyGroupId)
+    }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/DeleteStudiesDialog.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/DeleteStudiesDialog.kt
@@ -23,12 +23,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongPreviews
 import com.ssafy.neegongnaegong.presentation.ui.theme.NeeGongNaeGongTheme
 
 @Composable
 fun DeleteStudiesDialog(
     modifier: Modifier = Modifier,
+    role: Role,
     onCancel: () -> Unit,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
@@ -48,7 +50,11 @@ fun DeleteStudiesDialog(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
-                    text = "스터디 삭제",
+                    text = "스터디 ${if (role == Role.TEAM_LEADER) {
+                        "삭제"
+                    } else {
+                        "탈퇴"
+                    }}",
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold,
                     color = NeeGongNaeGongTheme.colorScheme.primaryText,
@@ -57,7 +63,11 @@ fun DeleteStudiesDialog(
                 Spacer(modifier = Modifier.height(32.dp))
 
                 Text(
-                    text = "스터디를 삭제 할까요?",
+                    text = "스터디를 ${if (role == Role.TEAM_LEADER) {
+                        "삭제"
+                    } else {
+                        "탈퇴"
+                    }} 할까요?",
                     fontSize = 14.sp,
                     color = Color.Gray,
                 )
@@ -117,6 +127,7 @@ private fun PreviewDeleteStudiesDialog() {
             onCancel = {},
             onDismiss = {},
             onConfirm = {},
+            role = Role.TEAM_LEADER,
         )
     }
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/StudiesDrawer.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/component/drawer/StudiesDrawer.kt
@@ -83,11 +83,12 @@ fun StudiesDrawerContent(
 
     if (uiState.showDeleteDialog) {
         DeleteStudiesDialog(
+            role = role,
             onCancel = { viewModel.setEvent(StudiesDetailContract.Event.OnDeleteDialogDismiss) },
             onDismiss = { viewModel.setEvent(StudiesDetailContract.Event.OnDeleteDialogDismiss) },
             onConfirm = {
                 viewModel.setEvent(
-                    StudiesDetailContract.Event.OndDeleteStudies(uiState.studyGroupDetailInfo.id),
+                    StudiesDetailContract.Event.OndDeleteStudies(uiState.studyGroupDetailInfo.id, role),
                 )
             },
         )
@@ -181,12 +182,19 @@ private fun StudiesDrawer(
             )
         }
 
-        if (role == Role.TEAM_LEADER) {
-            item {
+        item {
+            if (role == Role.TEAM_LEADER) {
                 // 스터디 삭제 버튼
                 DrawerMenuItem(
                     icon = R.drawable.ic_studies_drw_studies_delete,
                     title = stringResource(R.string.studies_drw_studies_delete),
+                    onClick = onStudyDeleteClick,
+                )
+            } else {
+                // 스터디 삭제 버튼
+                DrawerMenuItem(
+                    icon = R.drawable.ic_studies_drw_studies_delete,
+                    title = "그룹 탈퇴",
                     onClick = onStudyDeleteClick,
                 )
             }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailContract.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailContract.kt
@@ -32,6 +32,7 @@ class StudiesDetailContract {
 
         data class OndDeleteStudies(
             val studyGroupId: Long,
+            val role: Role,
         ) : Event
 
         data class OnClickLatestNotice(

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/detail/StudiesDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.ssafy.neegongnaegong.domain.model.studygroup.MyStudyGroupInfo
+import com.ssafy.neegongnaegong.domain.model.studygroup.Role
 import com.ssafy.neegongnaegong.domain.usecase.studies.DeleteStudiesUseCase
 import com.ssafy.neegongnaegong.domain.usecase.studies.GetStudiesFeedsUseCase
 import com.ssafy.neegongnaegong.domain.usecase.studies.GetStudiesLatestContentsUseCase
@@ -12,6 +13,7 @@ import com.ssafy.neegongnaegong.domain.usecase.studies.GetStudiesWeeklyRankingsU
 import com.ssafy.neegongnaegong.domain.usecase.studies.PatchStudiesLatestContentsReadStatusUseCase
 import com.ssafy.neegongnaegong.domain.usecase.studygroup.GetMyStudyListUseCase
 import com.ssafy.neegongnaegong.domain.usecase.studygroup.GetStudyGroupDetailUseCase
+import com.ssafy.neegongnaegong.domain.usecase.studygroup.LeaveStudyGroupUseCase
 import com.ssafy.neegongnaegong.presentation.base.BaseViewModel
 import com.ssafy.neegongnaegong.presentation.base.ErrorContext
 import com.ssafy.neegongnaegong.presentation.group.find.StudiesFindContract
@@ -33,6 +35,7 @@ class StudiesDetailViewModel
         private val getStudiesLatestContentsUseCase: GetStudiesLatestContentsUseCase,
         private val patchStudiesLatestContentsReadStatusUseCase: PatchStudiesLatestContentsReadStatusUseCase,
         private val deleteStudiesUseCase: DeleteStudiesUseCase,
+        private val leaveStudyGroupUseCase: LeaveStudyGroupUseCase,
         private val getMyStudyListUseCase: GetMyStudyListUseCase,
     ) : BaseViewModel<StudiesDetailContract.Event, StudiesDetailContract.State, StudiesDetailContract.Effect>() {
         var myStudyList: Flow<PagingData<MyStudyGroupInfo>> = emptyFlow()
@@ -55,7 +58,7 @@ class StudiesDetailViewModel
                 is StudiesDetailContract.Event.OnLoadWeeklyRankings -> onLoadWeeklyRankings(event.studyGroupId)
                 is StudiesDetailContract.Event.OnLoadLatestContents -> onLoadLatestContents(event.studyGroupId)
                 is StudiesDetailContract.Event.OndDeleteStudies -> {
-                    deleteStudies(event.studyGroupId)
+                    deleteStudies(event.studyGroupId, event.role)
                 }
                 is StudiesDetailContract.Event.OnClickLatestNotice -> {
                     setEffect {
@@ -179,15 +182,28 @@ class StudiesDetailViewModel
             }
         }
 
-        private fun deleteStudies(studyGroupId: Long) {
+        private fun deleteStudies(
+            studyGroupId: Long,
+            role: Role,
+        ) {
             viewModelScope.launch {
-                deleteStudiesUseCase(studyGroupId)
-                    .withLoading {
-                        setState { copy(isLoading = it) }
-                    }.safeCollect {
-                        showSuccessMessage("스터디가 삭제되었습니다.")
-                        setEffect { StudiesDetailContract.Effect.NavigateToMain }
-                    }
+                if (role == Role.TEAM_LEADER) {
+                    deleteStudiesUseCase(studyGroupId)
+                        .withLoading {
+                            setState { copy(isLoading = it) }
+                        }.safeCollect {
+                            showSuccessMessage("스터디가 삭제되었습니다.")
+                            setEffect { StudiesDetailContract.Effect.NavigateToMain }
+                        }
+                } else {
+                    leaveStudyGroupUseCase(studyGroupId)
+                        .withLoading {
+                            setState { copy(isLoading = it) }
+                        }.safeCollect {
+                            showSuccessMessage("스터디에서 탈퇴하셨습니다.")
+                            setEffect { StudiesDetailContract.Effect.NavigateToMain }
+                        }
+                }
             }
         }
 


### PR DESCRIPTION
## 📌 연결된 이슈
- #215 

### ✅ 작업 내용
- 그룹 탈퇴 API 연동
- 그룹 권한에 따라 그룹 (삭제/탈퇴) 메뉴로 수정 및 다이얼로그 안내 메뉴 또한 권한에 따라 (수정/탈퇴)로 표시되도록 수정

### 📷 관련 이미지(영상)
https://github.com/user-attachments/assets/708c2692-5882-4ce8-a776-023001f7ecd8


### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
