### PR TITLE
알림 API 관련 Response 수정 및 마이그레이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,5 @@ node_modules/
 .idea/studiobot.xml
 .kotlin/errors/errors-1750240286693.log
 .idea/csv-editor.xml
-app/schemas/
 app/neegongnaegong-release.jks
 

--- a/app/schemas/com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase/2.json
+++ b/app/schemas/com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase/2.json
@@ -1,0 +1,124 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "b2bd78bb0a618566f4592db639402c66",
+    "entities": [
+      {
+        "tableName": "notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `cursorId` INTEGER NOT NULL, `receiverId` INTEGER NOT NULL, `senderId` INTEGER NOT NULL, `notificationType` TEXT NOT NULL, `senderType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profileImg` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `read` INTEGER NOT NULL, `studyGroupId` INTEGER, `studyGroupName` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cursorId",
+            "columnName": "cursorId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receiverId",
+            "columnName": "receiverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderId",
+            "columnName": "senderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationType",
+            "columnName": "notificationType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderType",
+            "columnName": "senderType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileImg",
+            "columnName": "profileImg",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studyGroupId",
+            "columnName": "studyGroupId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "studyGroupName",
+            "columnName": "studyGroupName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "notification_remote_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nextCursor` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextCursor",
+            "columnName": "nextCursor",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b2bd78bb0a618566f4592db639402c66')"
+    ]
+  }
+}

--- a/app/schemas/com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase/3.json
+++ b/app/schemas/com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase/3.json
@@ -1,0 +1,204 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "31ee015e222a729722d6774a23c11ac2",
+    "entities": [
+      {
+        "tableName": "notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `cursorId` INTEGER NOT NULL, `receiverId` INTEGER NOT NULL, `senderId` INTEGER NOT NULL, `notificationType` TEXT NOT NULL, `senderType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profileImg` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `read` INTEGER NOT NULL, `studyGroupId` INTEGER, `studyGroupName` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cursorId",
+            "columnName": "cursorId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receiverId",
+            "columnName": "receiverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderId",
+            "columnName": "senderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationType",
+            "columnName": "notificationType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderType",
+            "columnName": "senderType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileImg",
+            "columnName": "profileImg",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studyGroupId",
+            "columnName": "studyGroupId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "studyGroupName",
+            "columnName": "studyGroupName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "notification_remote_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `nextCursor` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextCursor",
+            "columnName": "nextCursor",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "study_group_vote_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`studyGroupId` INTEGER NOT NULL, `id` INTEGER NOT NULL, `title` TEXT NOT NULL, `endTime` TEXT, `participationMember` INTEGER NOT NULL, `voted` INTEGER NOT NULL, PRIMARY KEY(`studyGroupId`, `id`))",
+        "fields": [
+          {
+            "fieldPath": "studyGroupId",
+            "columnName": "studyGroupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "participationMember",
+            "columnName": "participationMember",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "voted",
+            "columnName": "voted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "studyGroupId",
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "study_group_vote_history_remote_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`studyGroupId` INTEGER NOT NULL, `cursorTime` TEXT NOT NULL, `cursorId` INTEGER NOT NULL, PRIMARY KEY(`studyGroupId`, `cursorId`, `cursorTime`))",
+        "fields": [
+          {
+            "fieldPath": "studyGroupId",
+            "columnName": "studyGroupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cursorTime",
+            "columnName": "cursorTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cursorId",
+            "columnName": "cursorId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "studyGroupId",
+            "cursorId",
+            "cursorTime"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '31ee015e222a729722d6774a23c11ac2')"
+    ]
+  }
+}

--- a/app/schemas/com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase/4.json
+++ b/app/schemas/com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase/4.json
@@ -1,0 +1,214 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "0898da4631e33acd6ddaec8cea642037",
+    "entities": [
+      {
+        "tableName": "notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `cursorId` INTEGER NOT NULL, `receiverId` INTEGER NOT NULL, `senderId` INTEGER NOT NULL, `notificationType` TEXT NOT NULL, `senderType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profileImg` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `read` INTEGER NOT NULL, `studyGroupId` INTEGER, `studyGroupName` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cursorId",
+            "columnName": "cursorId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receiverId",
+            "columnName": "receiverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderId",
+            "columnName": "senderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationType",
+            "columnName": "notificationType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderType",
+            "columnName": "senderType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileImg",
+            "columnName": "profileImg",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studyGroupId",
+            "columnName": "studyGroupId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "studyGroupName",
+            "columnName": "studyGroupName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "notification_remote_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `cursorValue` TEXT, `cursorId` INTEGER, `first` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextCursor.cursorValue",
+            "columnName": "cursorValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nextCursor.cursorId",
+            "columnName": "cursorId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextCursor.first",
+            "columnName": "first",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "study_group_vote_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`studyGroupId` INTEGER NOT NULL, `id` INTEGER NOT NULL, `title` TEXT NOT NULL, `endTime` TEXT, `participationMember` INTEGER NOT NULL, `voted` INTEGER NOT NULL, PRIMARY KEY(`studyGroupId`, `id`))",
+        "fields": [
+          {
+            "fieldPath": "studyGroupId",
+            "columnName": "studyGroupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "participationMember",
+            "columnName": "participationMember",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "voted",
+            "columnName": "voted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "studyGroupId",
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "study_group_vote_history_remote_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`studyGroupId` INTEGER NOT NULL, `cursorTime` TEXT NOT NULL, `cursorId` INTEGER NOT NULL, PRIMARY KEY(`studyGroupId`, `cursorId`, `cursorTime`))",
+        "fields": [
+          {
+            "fieldPath": "studyGroupId",
+            "columnName": "studyGroupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cursorTime",
+            "columnName": "cursorTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cursorId",
+            "columnName": "cursorId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "studyGroupId",
+            "cursorId",
+            "cursorTime"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0898da4631e33acd6ddaec8cea642037')"
+    ]
+  }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/NeeGongNaeGongDatabase.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/NeeGongNaeGongDatabase.kt
@@ -21,7 +21,8 @@ import com.ssafy.neegongnaegong.data.local.database.entity.StudyGroupVoteHistory
         StudyGroupVoteHistory::class,
         StudyGroupVoteHistoryRemoteKey::class,
     ],
-    version = 3,
+    version = 4,
+    exportSchema = true,
     autoMigrations = [
         // 투표 목록 저장하는 Table 생성
         AutoMigration(from = 2, to = 3),

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/data/NotificationMapper.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/data/NotificationMapper.kt
@@ -4,6 +4,7 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationRemoteKeyEntity
+import com.ssafy.neegongnaegong.data.model.cursor.NextCursorData
 import com.ssafy.neegongnaegong.data.model.notification.GetNotificationResponse
 import com.ssafy.neegongnaegong.data.model.notification.NotificationRemoteType
 import com.ssafy.neegongnaegong.domain.model.notification.Notification
@@ -13,13 +14,16 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 
 internal object NotificationMapper {
-    fun GetNotificationResponse.toKey(cursorId: Long?) =
+    fun GetNotificationResponse.toKey(cursorId: NextCursorData?) =
         NotificationRemoteKeyEntity(
             id = id,
             nextCursor = cursorId,
         )
 
-    fun List<GetNotificationResponse>.toKey(cursorId: Long?): List<NotificationRemoteKeyEntity> = map { it.toKey(cursorId = cursorId) }
+    fun List<GetNotificationResponse>.toKey(cursorId: NextCursorData?): List<NotificationRemoteKeyEntity> =
+        map {
+            it.toKey(cursorId = cursorId)
+        }
 
     fun GetNotificationResponse.toEntity() =
         NotificationEntity(

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/entity/NotificationRemoteKeyEntity.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/entity/NotificationRemoteKeyEntity.kt
@@ -1,11 +1,14 @@
 package com.ssafy.neegongnaegong.data.local.database.entity
 
+import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.ssafy.neegongnaegong.data.model.cursor.NextCursorData
 
 @Entity(tableName = "notification_remote_keys")
 data class NotificationRemoteKeyEntity(
     @PrimaryKey
     val id: Long,
-    val nextCursor: Long?,
+    @Embedded
+    val nextCursor: NextCursorData?,
 )

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/migration/MigrationFrom3To4.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/migration/MigrationFrom3To4.kt
@@ -1,0 +1,30 @@
+package com.ssafy.neegongnaegong.data.local.database.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class MigrationFrom3To4 : Migration(3, 4) {
+    /**
+     * 이번 마이그레이션에서는 커서 관련 response가 바뀜에 따라 Notification RemoteKey 테이블의 컬럼 속성이 변경되었습니다.
+     * NotificationRemoteKeyEntity의 Key 속성 변경
+     * 기존 : id: String, nextCursor: Long?
+     * 수정 : id: String, nextCursor: NextCursorData?(embedded)
+     *
+     * 테이블 구조가 바뀌어 어쩔 수 없이 그냥 테이블을 삭제 후 재 생성하는 것으로 결정하였습니다
+     */
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("DROP TABLE IF EXISTS notification_remote_keys")
+
+        database.execSQL(
+            """
+            CREATE TABLE `notification_remote_keys` (
+                `id` INTEGER NOT NULL, 
+                `cursorValue` TEXT, 
+                `cursorId` INTEGER, 
+                `first` INTEGER, 
+                PRIMARY KEY(`id`)
+            )
+        """,
+        )
+    }
+}

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/module/DBModule.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/local/database/module/DBModule.kt
@@ -6,6 +6,7 @@ import com.ssafy.neegongnaegong.data.local.database.NeeGongNaeGongDatabase
 import com.ssafy.neegongnaegong.data.local.database.dao.LocalNotificationDataSource
 import com.ssafy.neegongnaegong.data.local.database.dao.LocalNotificationRemoteKeyDataSource
 import com.ssafy.neegongnaegong.data.local.database.migration.MigrationFrom1To2
+import com.ssafy.neegongnaegong.data.local.database.migration.MigrationFrom3To4
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -27,7 +28,7 @@ object DBModule {
                 klass = NeeGongNaeGongDatabase::class.java,
                 name = "neegongnaegong.db",
             )
-            .addMigrations(MigrationFrom1To2())
+            .addMigrations(MigrationFrom1To2(), MigrationFrom3To4())
             .build()
 
     @Singleton

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/model/notification/NotificationPage.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/model/notification/NotificationPage.kt
@@ -1,7 +1,9 @@
 package com.ssafy.neegongnaegong.data.model.notification
 
+import com.ssafy.neegongnaegong.data.model.cursor.NextCursorData
+
 data class NotificationPage(
     val content: List<GetNotificationResponse>,
     val hasNext: Boolean,
-    val cursorId: Long?,
+    val nextCursor: NextCursorData,
 )

--- a/app/src/main/java/com/ssafy/neegongnaegong/data/paging/NotificationRemoteMediator.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/data/paging/NotificationRemoteMediator.kt
@@ -14,6 +14,7 @@ import com.ssafy.neegongnaegong.data.local.database.data.NotificationMapper.toEn
 import com.ssafy.neegongnaegong.data.local.database.data.NotificationMapper.toKey
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationEntity
 import com.ssafy.neegongnaegong.data.local.database.entity.NotificationRemoteKeyEntity
+import com.ssafy.neegongnaegong.data.model.cursor.NextCursorData
 import com.ssafy.neegongnaegong.data.model.notification.NotificationPage
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
@@ -34,7 +35,7 @@ class NotificationRemoteMediator
             loadType: LoadType,
             state: PagingState<Int, NotificationEntity>,
         ): MediatorResult {
-            val cursor: Long? =
+            val cursor: NextCursorData? =
                 when (loadType) {
                     LoadType.REFRESH -> null
                     LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
@@ -43,7 +44,7 @@ class NotificationRemoteMediator
                             getRemoteKeyForLastItem(state = state)
                                 ?: return MediatorResult.Success(endOfPaginationReached = false)
 
-                        val nextCursor: Long =
+                        val nextCursor =
                             remoteKey.nextCursor
                                 ?: return MediatorResult.Success(endOfPaginationReached = true)
                         nextCursor
@@ -53,7 +54,7 @@ class NotificationRemoteMediator
             return runCatching {
                 val remotePager: NotificationPage =
                     networkNotificationDataSource.getNotifications(
-                        cursorId = cursor,
+                        cursorId = cursor?.cursorId,
                         size = state.config.pageSize,
                     ).first()
                 val endOfPaginationReached: Boolean = !remotePager.hasNext
@@ -64,7 +65,7 @@ class NotificationRemoteMediator
                         localNotificationDataSource.clearAll()
                     }
 
-                    remoteKeyDao.insertAll(keys = remotePager.content.toKey(cursorId = remotePager.cursorId))
+                    remoteKeyDao.insertAll(keys = remotePager.content.toKey(cursorId = remotePager.nextCursor))
 
                     localNotificationDataSource.insertAll(notifications = remotePager.content.toEntity())
                 }


### PR DESCRIPTION
## 📌 연결된 이슈
- #224

### ✅ 작업 내용
- 알림 API Response 속성 수정
- Remote Mediator 수정 및 Remote Key 변경으로 인한 Migration

### 📷 관련 이미지(영상)

|수정 후 화면|
|:--:|
|<img width="300" height="2376" alt="image" src="https://github.com/user-attachments/assets/7dbb9675-ad24-4154-af14-338d3c474bc3" />|

|RemoteKey 수정 후 구조|
|:--:|
|<img width="1076" height="170" alt="image" src="https://github.com/user-attachments/assets/90fc0463-340c-402a-b639-8ff0e66a33b6" />|

|DB 이전 관련 공식 문서|
|:--:|
|<img width="1315" height="196" alt="image" src="https://github.com/user-attachments/assets/6f3a480f-66f2-4807-ab46-9a4d90b0be6a" />|


### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
- 전에 `Metrics`를 설정할 때 `Room Schema` 관련 에러가 나서 설정을 해줬습니다.
- 당시에는 에러를 해결하기 위함이었고, `Room Schema`가 정확하게 무엇을 위함인지를 몰라서 `build` 같은 부산물로 인지하고, `gitignore`에 넣어 추가되는 것을 막았습니다
- 이번에 `Migration` 작업 도중 이번 4버전으로 `Migration` 하는 작업은 **수동 Migration**으로 진행했음에도 불구하고 계속해서 `AutoMigration` 관련 에러가 떴었습니다
- 한참이 지나고서야 결론적으로 무언가 잘못 건드렸는지 **3버전 json이 오염되어** 4버전 내용이 반영된 `schema`로 바뀐 것으로 파악됐습니다.
- `clean project`, `invalidate cache`, `schemas`폴더 삭제 등을 다 해보았지만 **오염된 3버전은 다시 돌아오질 않았습니다.**
- 심지어 **버전 관리도 되어 있지 않았기 때문에** 간신히 @todayis-sunny 님이 가지고 계시던 `3.json` 파일을 받아서 **복구 및 작업을 진행할 수 있었습니다**

- 결론적으로 해결하고 난 이후에야 공식 문서를 들여다볼 여유가 생기게 되었는데, 최근 `Room`을 다시 복습할 때 `Entity` 등 `Room`을 만드는 과정 등에 대해서 다시 복습을 하였지만, 이것과 관련된 내용은 미처 확인하지 못한 [Room Database 이전](https://developer.android.com/training/data-storage/room/migrating-db-versions?hl=ko)에 있었습니다
- 관련 이미지의 DB 이전 관련 공식 문서의 이미지를 보시면 알 수 있듯이 이 json으로 구성된 `Schema`는 **Room 관련 Testing** 혹은 `AutoMigration`시 차이를 비교하여 자동으로 처리해주는 등의 기능을 위해 존재하는 것으로 파악됩니다
- 별개로 이번 `Room Migration`은 `Notification의 Slicing API`의 `Response Key` 가 바뀜에 따라 `RemoteKey`를 바뀌면서 생긴 변경점을 적용하였고, `Embedded` 어노테이션을 이용하여 **해당 `DataType` 자체를 저장하는 것이 아니라 DataType 내의 속성들이 들어오도록 설정했습니다**
- 이를 수정 후 구조 이미지에서 확인하실 수 있습니다