### PR TITLE
공지 생성 시 텍스트 컬러 다크모드 대응

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/notice/NoticeScreen.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/group/notice/NoticeScreen.kt
@@ -117,7 +117,7 @@ fun NoticeContent(
                 Modifier
                     .fillMaxWidth(),
             // 여기선 Text 자체 padding 조절
-            textStyle = NeeGongNaeGongTheme.typography.titleSmall,
+            textStyle = NeeGongNaeGongTheme.typography.titleSmall.copy(color = NeeGongNaeGongTheme.colorScheme.primaryText),
             cursorBrush = SolidColor(NeeGongNaeGongTheme.colorScheme.primaryText),
         )
 
@@ -141,7 +141,7 @@ fun NoticeContent(
                     .weight(1F)
                     .padding(0.dp),
             // 여기선 Text 자체 padding 조절
-            textStyle = NeeGongNaeGongTheme.typography.bodyMedium,
+            textStyle = NeeGongNaeGongTheme.typography.bodyMedium.copy(color = NeeGongNaeGongTheme.colorScheme.primaryText),
             cursorBrush = SolidColor(NeeGongNaeGongTheme.colorScheme.primaryText),
         )
     }


### PR DESCRIPTION
## 📌 연결된 이슈
- #239 

### ✅ 작업 내용
- 다크모드 대응이 안되어 다크모드 시 타이핑 한 내용이 잘 안보이던 것을 수정

### 📷 관련 이미지(영상)
|적용 전 화면|수정 후|
|:--:|:--:|
|<img width="968" height="2376" alt="image" src="https://github.com/user-attachments/assets/f8e5c2c8-5c11-46b3-ab05-3a593d816066" />|<img width="968" height="2376" alt="image" src="https://github.com/user-attachments/assets/889016bf-828e-48f2-aedb-cb1bb4ee5b9a" />|



### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
