### PR TITLE
Domain의 Model을 r8에서 예외처리

### DIFF
--- a/app/model.pro
+++ b/app/model.pro
@@ -2,6 +2,8 @@
 # 정확히는 gson의 SerializaeName 어노테이션을 모든 request 및 response에 붙혀서 api 통신할 때 쓰이는 것만 안되도록 막는 게 맞음
 # 추후 변경해야 함 - 또한 Gson에서 serialization으로 변경하는 것도 검토 대상
 -keep class com.ssafy.neegongnaegong.data.model.** { *; }
+# API의 Response의 일부 데이터 타입을 Domain Type을 가져다 쓴 것이 있어서 우선 domain model 또한 난독화에서 제외시킴
+-keep class com.ssafy.neegongnaegong.domain.model.** { *; }
 
 #  Ensure that the serialName for this argument is the default fully qualified name 처럼 serialName 관련해서 클래스 이름이 변해서 에러가 나는 것 막아야 함
 -keepnames enum * {


### PR DESCRIPTION
## 📌 연결된 이슈
- #245 
### ✅ 작업 내용
- `Api`의 `Response`로 `Domain`내의 모델로 쓴 것이 있어 우선 예외처리

### 📷 관련 이미지(영상)

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
- 이상적으로는 `API` 통신을 해서 받는 `Request`와 `Response`를 `Gson`의 SerializedName 같은 `Annotation`으로 명시해서 `Gson`을 쓰는 Type의 경우 `r8`의 최적화에서 제외해서 type이 변형되거나 하는 것을 막아야 하지만 현재 파일에서 갑자기 전부 적용하기가 어려워서 `Data`에서 `Model`에 속하던 `Data Class`들을 전부 예외하는 식으로 적용했습니다.
- 그런데 그럼에도 스터디 목록을 검색할 때 `Debug`와 달리 `Release`에서만 제대로 되지 않는 것을 확인해서 원인을 찾아본 결과 `Domain`에 존재하는 `Data Class`의 타입을 `Response`의 속성 일부 타입으로 사용해서 이쪽이 제대로 안 받아와지면서 생기는 문제로 파악했습니다
- 그런데 `Domain`쪽에 `Gson`을 적용하기도 그렇고, 저 `API`만 `Domain`에 있는 `Model`을 땡겨썼다고 확신할 수 없기 때문에 우선 `Domain`의 `Model` 내부에 속하는 `Data Class`파일들도 적용되지 않도록 rule을 추가 적용했습니다.

- 사실 `Gson`을 쓰는게 좋지 않기에 `Serialization`으로 바꾸고 싶은 마음이 있으나 될 지 모르겠습니다...
- `Serialization`을 쓰고, `Serialization` 어노테이션을 쓴 것들은 `r8`에서 제외하도록 하는게 좋지 않을까 생각했습니다