### PR TITLE
fix(#251): 버튼을 여러 번 누르면 작업이 처리되기 전에 다중 실행되는 것 수정

### DIFF
--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/LoadingDialog.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/component/LoadingDialog.kt
@@ -1,6 +1,7 @@
 package com.ssafy.neegongnaegong.presentation.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
@@ -16,7 +17,7 @@ fun LoadingDialog(modifier: Modifier = Modifier) {
         modifier =
             modifier
                 .fillMaxSize()
-                .background(color = NeeGongNaeGongTheme.colorScheme.background.copy(alpha = 0.5f)),
+                .background(color = NeeGongNaeGongTheme.colorScheme.background.copy(alpha = 0.5f)).clickable { /* 터치 이벤트 흡수 */ },
         contentAlignment = Alignment.Center,
     ) {
         CircularProgressIndicator(

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationRoute.kt
@@ -99,5 +99,5 @@ fun NotificationRoute(
         },
     )
 
-    if (uiState.isModifying) LoadingDialog()
+    if (uiState.isModifying || uiState.isLoading) LoadingDialog()
 }

--- a/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ssafy/neegongnaegong/presentation/notification/NotificationViewModel.kt
@@ -108,7 +108,7 @@ class NotificationViewModel
                     studyGroupId = data.studyGroupId,
                     userId = data.senderId,
                     notificationId = data.id,
-                ).firstOrNull()
+                ).withLoading(0) { setState { copy(isModifying = it) } }.firstOrNull()
             }
         }
 
@@ -118,7 +118,7 @@ class NotificationViewModel
                     studyGroupId = data.studyGroupId,
                     userId = data.senderId,
                     notificationId = data.id,
-                ).firstOrNull()
+                ).withLoading { setState { copy(isModifying = it) } }.firstOrNull()
             }
         }
 


### PR DESCRIPTION
## 📌 연결된 이슈
- #251

### ✅ 작업 내용
- 그룹 승인, 거절 작업 시 `Loading`이 활성화되도록 수정
- `LoadingBar`에서 `Clickable`로 `click` 이벤트를 흡수하여 아래의 승인 버튼 등에 클릭 이벤트가 들어가지 않도록 수정

### 📷 관련 이미지(영상)
|화면|
|:--:|
|<video src=https://github.com/user-attachments/assets/da4e54bc-7a96-495f-b013-ed9a803bf6fa control/>|

|로그|
|:--:|
|<video src=https://github.com/user-attachments/assets/3dd47cff-c0c7-44f4-a4bd-9022fefe916f control/>|

### 🤔 의논하고 싶은 내용(코드 리뷰 받고 싶은 부분)
